### PR TITLE
将`cp`替换为Windows下等价指令`Xcopy`

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -7,10 +7,22 @@ config_output_file = configure_file(
   output: 'config.rs',
   configuration: conf
 )
+
 # Copy the config.rs output to the source directory.
-run_command(
-  'cp',
-  config_output_file,
-  meson.current_source_dir(),
-  check: true
-)
+if build_machine.system() == 'windows'
+  run_command(
+    'Xcopy',
+    config_output_file,
+    meson.current_source_dir(),
+    # overwrite exist file
+    '/y',
+    check: true
+  )
+else
+  run_command(
+    'cp',
+    config_output_file,
+    meson.current_source_dir(),
+    check: true
+  )
+endif


### PR DESCRIPTION
- [x] using `Xcopy` replace `cp`
  - [x] using `/y` to overwirte file