### PR TITLE
♻️ (avatar) 重构登录界面头像加载逻辑

### DIFF
--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -473,9 +473,7 @@ impl SimpleComponent for LoginPageModel {
             .go_next_button
             .set_sensitive(self.is_login_button_enabled);
 
-        // TODO: IF ELSE HELL!!! Someone helps improve here please.
-
-        let pix_buf_owner = self
+        let paint = self
             .account
             .parse::<i64>()
             .ok()
@@ -485,6 +483,6 @@ impl SimpleComponent for LoginPageModel {
 
         widgets
             .avatar
-            .set_custom_image(Into::<Option<&'_ Paintable>>::into(&pix_buf_owner));
+            .set_custom_image(Into::<Option<&'_ Paintable>>::into(&paint));
     }
 }

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -23,6 +23,7 @@ use tokio::{
     task,
 };
 
+use crate::utils::avatar::loader::{AvatarLoader, User};
 use crate::{
     actions::{AboutAction, ShortcutsAction},
     db::sql::get_db,
@@ -473,24 +474,17 @@ impl SimpleComponent for LoginPageModel {
             .set_sensitive(self.is_login_button_enabled);
 
         // TODO: IF ELSE HELL!!! Someone helps improve here please.
-        if let Ok(account) = self.account.parse::<i64>() {
-            let path = get_user_avatar_path(account);
-            if path.exists() {
-                if let Ok(pixbuf) = Pixbuf::from_file_at_size(path, 96, 96) {
-                    let image = Picture::for_pixbuf(&pixbuf);
-                    if let Some(paintable) = image.paintable() {
-                        widgets.avatar.set_custom_image(Some(&paintable));
-                    } else {
-                        widgets.avatar.set_custom_image(Option::<&Paintable>::None);
-                    }
-                } else {
-                    widgets.avatar.set_custom_image(Option::<&Paintable>::None);
-                }
-            } else {
-                widgets.avatar.set_custom_image(Option::<&Paintable>::None);
-            }
-        } else {
-            widgets.avatar.set_custom_image(Option::<&Paintable>::None);
-        }
+
+        let pix_buf_owner = self
+            .account
+            .parse::<i64>()
+            .ok()
+            .and_then(|id| User::get_avatar_as_pixbuf(id, 96, 96).ok())
+            .map(|pix_buf| Picture::for_pixbuf(&pix_buf))
+            .and_then(|pic| pic.paintable());
+
+        widgets
+            .avatar
+            .set_custom_image(Into::<Option<&'_ Paintable>>::into(&pix_buf_owner));
     }
 }

--- a/src/utils/avatar/error.rs
+++ b/src/utils/avatar/error.rs
@@ -4,6 +4,7 @@ use std::io;
 pub enum AvatarError {
     Io(io::Error),
     Request(reqwest::Error),
+    Glib(relm4::gtk::glib::Error),
 }
 
 impl std::fmt::Display for AvatarError {
@@ -11,6 +12,7 @@ impl std::fmt::Display for AvatarError {
         match self {
             AvatarError::Io(err) => write!(f, "Avatar Io Error : {}", err),
             AvatarError::Request(err) => write!(f, "Avatar Request Error : {}", err),
+            AvatarError::Glib(err) => write!(f, "Avatar GLib Error : {}", err),
         }
     }
 }
@@ -24,5 +26,11 @@ impl From<io::Error> for AvatarError {
 impl From<reqwest::Error> for AvatarError {
     fn from(err: reqwest::Error) -> Self {
         AvatarError::Request(err)
+    }
+}
+
+impl From<relm4::gtk::glib::Error> for AvatarError {
+    fn from(err: relm4::gtk::glib::Error) -> Self {
+        AvatarError::Glib(err)
     }
 }

--- a/src/utils/avatar/loader/mod.rs
+++ b/src/utils/avatar/loader/mod.rs
@@ -6,6 +6,7 @@ use std::{borrow::Cow, future::Future, io, path::PathBuf, pin::Pin};
 use super::error::AvatarError;
 use crate::utils::DirAction;
 pub use group::Group;
+use relm4::gtk::gdk_pixbuf::Pixbuf;
 pub use user::User;
 
 pub trait AvatarLoader {
@@ -37,5 +38,18 @@ pub trait AvatarLoader {
 
     fn get_avatar(id: i64) -> io::Result<PathBuf> {
         <Self as AvatarLoader>::get_avatar_filename(id, DirAction::None)
+    }
+
+    fn get_avatar_as_pixbuf(id: i64, width: i32, height: i32) -> Result<Pixbuf, AvatarError> {
+        let path = <Self as AvatarLoader>::get_avatar(id)?;
+        if !path.exists() {
+            Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "Target Avatar Not Found",
+            ))?;
+        }
+        let pix_buf = Pixbuf::from_file_at_size(path, width, height)?;
+
+        Ok(pix_buf)
     }
 }


### PR DESCRIPTION
-[x] avatar loader 增加 直接将文件加载为 `PixBuf` 接口
-[x] 干碎登录界面头像加载时的if hell


~你那个嵌套if 让我感觉你对 `Option` 和 `Result` 那些配套方法很不熟欸~