### PR TITLE
登录部分逻辑重构

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,6 +2788,7 @@ version = "0.1.0"
 dependencies = [
  "dirs",
  "relm4",
+ "ricq",
  "typed-builder",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +977,8 @@ name = "gtk-qq"
 version = "0.2.0"
 dependencies = [
  "async-trait",
+ "base64",
+ "bincode",
  "once_cell",
  "qrcode-png",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,8 @@ dependencies = [
  "dirs",
  "log",
  "once_cell",
+ "rand",
+ "ricq",
  "serde",
  "serde_json",
  "tap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,8 @@ reqwest = "0.11.10"
 qrcode-png = "0.4.0"
 typed-builder = "0.10"
 
+bincode = "1.3.3" 
+base64 = "0.13.0"
+
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "./libs/widgets"
 path = "./libs/resource-loader"
 
 [dependencies]
-tokio = "1.18.2"
+tokio = { version = "1.18.2", features = ["sync"] }
 rand = "0.8.5"
 async-trait = "0.1.53"
 once_cell = "1.11.0"
@@ -32,8 +32,7 @@ rusqlite = "0.27.0"
 reqwest = "0.11.10"
 qrcode-png = "0.4.0"
 typed-builder = "0.10"
-
-bincode = "1.3.3" 
+bincode = "1.3.3"
 base64 = "0.13.0"
 
 [profile.release]

--- a/libs/resource-loader/Cargo.toml
+++ b/libs/resource-loader/Cargo.toml
@@ -18,6 +18,12 @@ tokio = { version = "1", features = ["fs"] }
 tempfile = "3.3"
 toml = "0.5.9"
 tap = "1"
+rand = "0.8.5"
 
 [dev-dependencies]
 serde_json = "1"
+
+[dependencies.ricq]
+git = "https://github.com/lz1998/ricq.git"
+# v0.1.10, master, 2022/06/08
+rev = "38fff7007cb51bc39acc30087c3f042031a38eda"

--- a/libs/resource-loader/src/configs/client.rs
+++ b/libs/resource-loader/src/configs/client.rs
@@ -1,0 +1,50 @@
+use derivative::Derivative;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Derivative)]
+#[derivative(Default)]
+pub struct ClientConfig {
+    #[serde(default = "Default::default")]
+    #[derivative(Default(value = "Default::default()"))]
+    pub(crate) protocol: Protocol,
+
+    #[serde(default = "default_seed")]
+    #[derivative(Default(value = "default_seed()"))]
+    pub(crate) device_seed: u64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Derivative, Deserialize)]
+#[derivative(Default)]
+pub enum Protocol {
+    #[serde(alias = "ipad")]
+    IPad,
+    #[serde(alias = "android-phone")]
+    #[serde(alias = "android_phone")]
+    AndroidPhone,
+    #[serde(alias = "android-watch")]
+    #[serde(alias = "android_watch")]
+    AndroidWatch,
+    #[derivative(Default)]
+    #[serde(alias = "macos")]
+    MacOS,
+    #[serde(alias = "qi_dian")]
+    #[serde(alias = "qi-dian")]
+    QiDian,
+}
+
+impl Into<ricq::version::Protocol> for Protocol {
+    fn into(self) -> ricq::version::Protocol {
+        use ricq::version::Protocol::*;
+        match self {
+            Protocol::IPad => IPad,
+            Protocol::AndroidPhone => AndroidPhone,
+            Protocol::AndroidWatch => AndroidWatch,
+            Protocol::MacOS => MacOS,
+            Protocol::QiDian => QiDian,
+        }
+    }
+}
+
+fn default_seed() -> u64 {
+    1145141919810
+}

--- a/libs/resource-loader/src/configs/client.rs
+++ b/libs/resource-loader/src/configs/client.rs
@@ -1,4 +1,5 @@
 use derivative::Derivative;
+use ricq::version::{get_version, Version};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Derivative)]
@@ -6,11 +7,25 @@ use serde::{Deserialize, Serialize};
 pub struct ClientConfig {
     #[serde(default = "Default::default")]
     #[derivative(Default(value = "Default::default()"))]
-    pub(crate) protocol: Protocol,
+    protocol: Protocol,
 
     #[serde(default = "default_seed")]
     #[derivative(Default(value = "default_seed()"))]
+    device_seed: u64,
+}
+
+pub struct ClientInner {
     pub(crate) device_seed: u64,
+    pub(crate) version: &'static Version,
+}
+
+impl From<ClientConfig> for ClientInner {
+    fn from(cfg: ClientConfig) -> Self {
+        ClientInner {
+            device_seed: cfg.device_seed,
+            version: get_version(cfg.protocol.into()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Derivative, Deserialize)]

--- a/libs/resource-loader/src/configs/client.rs
+++ b/libs/resource-loader/src/configs/client.rs
@@ -32,10 +32,10 @@ pub enum Protocol {
     QiDian,
 }
 
-impl Into<ricq::version::Protocol> for Protocol {
-    fn into(self) -> ricq::version::Protocol {
+impl From<Protocol> for ricq::version::Protocol {
+    fn from(val: Protocol) -> Self {
         use ricq::version::Protocol::*;
-        match self {
+        match val {
             Protocol::IPad => IPad,
             Protocol::AndroidPhone => AndroidPhone,
             Protocol::AndroidWatch => AndroidWatch,

--- a/libs/resource-loader/src/configs/config.rs
+++ b/libs/resource-loader/src/configs/config.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     avatar::AvatarConfig,
-    client::ClientConfig,
+    client::{ClientConfig, ClientInner},
     local_db::DbConfig,
     temporary::{InnerTemporaryConfig, TemporaryConfig},
     InnerAvatarConfig, InnerDbConfig,
@@ -35,7 +35,7 @@ pub struct InnerConfig {
     pub(crate) temporary: InnerTemporaryConfig,
     pub(crate) avatar: InnerAvatarConfig,
     pub(crate) database: InnerDbConfig,
-    pub(crate) client: ClientConfig,
+    pub(crate) client: ClientInner,
 }
 
 impl Config {
@@ -46,7 +46,7 @@ impl Config {
             avatar: self.avatar.into_inner(root.as_path()),
             database: self.database.into_inner(root.as_path()),
             temporary: self.temporary.into_inner(),
-            client: self.client,
+            client: self.client.into(),
         }
     }
 }

--- a/libs/resource-loader/src/configs/config.rs
+++ b/libs/resource-loader/src/configs/config.rs
@@ -35,7 +35,7 @@ pub struct InnerConfig {
     pub(crate) temporary: InnerTemporaryConfig,
     pub(crate) avatar: InnerAvatarConfig,
     pub(crate) database: InnerDbConfig,
-    pub(crate) client:ClientConfig
+    pub(crate) client: ClientConfig,
 }
 
 impl Config {

--- a/libs/resource-loader/src/configs/config.rs
+++ b/libs/resource-loader/src/configs/config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     avatar::AvatarConfig,
+    client::ClientConfig,
     local_db::DbConfig,
     temporary::{InnerTemporaryConfig, TemporaryConfig},
     InnerAvatarConfig, InnerDbConfig,
@@ -26,12 +27,15 @@ pub struct Config {
     avatar: AvatarConfig,
     #[serde(default = "Default::default")]
     database: DbConfig,
+    #[serde(default = "Default::default")]
+    client: ClientConfig,
 }
 
 pub struct InnerConfig {
     pub(crate) temporary: InnerTemporaryConfig,
     pub(crate) avatar: InnerAvatarConfig,
     pub(crate) database: InnerDbConfig,
+    pub(crate) client:ClientConfig
 }
 
 impl Config {
@@ -42,6 +46,7 @@ impl Config {
             avatar: self.avatar.into_inner(root.as_path()),
             database: self.database.into_inner(root.as_path()),
             temporary: self.temporary.into_inner(),
+            client: self.client,
         }
     }
 }

--- a/libs/resource-loader/src/configs/mod.rs
+++ b/libs/resource-loader/src/configs/mod.rs
@@ -1,3 +1,4 @@
+mod client;
 mod config;
 use std::path::Path;
 

--- a/libs/resource-loader/src/lib.rs
+++ b/libs/resource-loader/src/lib.rs
@@ -10,8 +10,8 @@ pub use static_data::ResourceConfig;
 
 pub use ops::{
     avatar::{Group as AvatarGroup, User as AvatarUser},
+    client::{Device, Protocol},
     database::SqlDataBase,
     temporary::{CaptchaQrCode, TempDir},
-    client::{Device,Protocol},
     AsyncCreatePath, AsyncLoadResource, DirAction, GetPath, SyncCreatePath, SyncLoadResource,
 };

--- a/libs/resource-loader/src/lib.rs
+++ b/libs/resource-loader/src/lib.rs
@@ -12,5 +12,6 @@ pub use ops::{
     avatar::{Group as AvatarGroup, User as AvatarUser},
     database::SqlDataBase,
     temporary::{CaptchaQrCode, TempDir},
+    client::{Device,Protocol},
     AsyncCreatePath, AsyncLoadResource, DirAction, GetPath, SyncCreatePath, SyncLoadResource,
 };

--- a/libs/resource-loader/src/ops/client.rs
+++ b/libs/resource-loader/src/ops/client.rs
@@ -1,7 +1,6 @@
 use std::convert::Infallible;
 
 use rand::{prelude::StdRng, SeedableRng};
-use ricq::version::get_version;
 
 use crate::{static_data::load_cfg, SyncLoadResource};
 

--- a/libs/resource-loader/src/ops/client.rs
+++ b/libs/resource-loader/src/ops/client.rs
@@ -6,14 +6,16 @@ use crate::{static_data::load_cfg, SyncLoadResource};
 
 pub struct Device;
 
-impl SyncLoadResource<StdRng> for Device {
+impl SyncLoadResource<ricq::device::Device> for Device {
     type Args = ();
 
     type Error = Infallible;
 
-    fn load_resource(_: Self::Args) -> Result<StdRng, Self::Error> {
+    fn load_resource(_: Self::Args) -> Result<ricq::device::Device, Self::Error> {
         let seed = load_cfg().client.device_seed;
-        Ok(StdRng::seed_from_u64(seed))
+        Ok(ricq::device::Device::random_with_rng(
+            &mut StdRng::seed_from_u64(seed),
+        ))
     }
 }
 

--- a/libs/resource-loader/src/ops/client.rs
+++ b/libs/resource-loader/src/ops/client.rs
@@ -26,6 +26,6 @@ impl SyncLoadResource<&'static ricq::version::Version> for Protocol {
     type Error = Infallible;
 
     fn load_resource(_: Self::Args) -> Result<&'static ricq::version::Version, Self::Error> {
-        Ok(get_version(load_cfg().client.protocol.into()))
+        Ok(load_cfg().client.version)
     }
 }

--- a/libs/resource-loader/src/ops/client.rs
+++ b/libs/resource-loader/src/ops/client.rs
@@ -1,0 +1,31 @@
+use std::convert::Infallible;
+
+use rand::{prelude::StdRng, SeedableRng};
+use ricq::version::get_version;
+
+use crate::{static_data::load_cfg, SyncLoadResource};
+
+pub struct Device;
+
+impl SyncLoadResource<StdRng> for Device {
+    type Args = ();
+
+    type Error = Infallible;
+
+    fn load_resource(_: Self::Args) -> Result<StdRng, Self::Error> {
+        let seed = load_cfg().client.device_seed;
+        Ok(StdRng::seed_from_u64(seed))
+    }
+}
+
+pub struct Protocol;
+
+impl SyncLoadResource<&'static ricq::version::Version> for Protocol {
+    type Args = ();
+
+    type Error = Infallible;
+
+    fn load_resource(_: Self::Args) -> Result<&'static ricq::version::Version, Self::Error> {
+        Ok(get_version(load_cfg().client.protocol.into()))
+    }
+}

--- a/libs/resource-loader/src/ops/mod.rs
+++ b/libs/resource-loader/src/ops/mod.rs
@@ -1,5 +1,5 @@
-pub mod client;
 pub mod avatar;
+pub mod client;
 pub mod database;
 pub mod temporary;
 use std::path::Path;

--- a/libs/resource-loader/src/ops/mod.rs
+++ b/libs/resource-loader/src/ops/mod.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod avatar;
 pub mod database;
 pub mod temporary;

--- a/libs/widgets/Cargo.toml
+++ b/libs/widgets/Cargo.toml
@@ -14,3 +14,8 @@ features = ["macros", "libadwaita"]
 [dependencies]
 typed-builder = "0.10"
 dirs = "4.0.0"
+
+[dependencies.ricq]
+git = "https://github.com/lz1998/ricq.git"
+# v0.1.10, master, 2022/06/08
+rev = "38fff7007cb51bc39acc30087c3f042031a38eda"

--- a/libs/widgets/src/lib.rs
+++ b/libs/widgets/src/lib.rs
@@ -1,2 +1,2 @@
-pub mod pwd_login;
 pub mod link_copier;
+pub mod pwd_login;

--- a/libs/widgets/src/lib.rs
+++ b/libs/widgets/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod pwd_login;
 pub mod link_copier;

--- a/libs/widgets/src/pwd_login/component.rs
+++ b/libs/widgets/src/pwd_login/component.rs
@@ -1,0 +1,95 @@
+use relm4::gtk::{
+    self,
+    gdk::Paintable,
+    traits::{EditableExt, WidgetExt},
+};
+
+use super::{
+    payloads::{Input, Output, Payload},
+    widgets::PwdLoginWidget,
+};
+
+pub struct PasswordLoginModel {
+    account_changed: bool,
+    account: Option<i64>,
+    password: Option<String>,
+}
+
+impl relm4::SimpleComponent for PasswordLoginModel {
+    type Input = Input;
+
+    type Output = Output;
+
+    type InitParams = Payload;
+
+    type Root = gtk::Box;
+
+    type Widgets = PwdLoginWidget;
+
+    fn init_root() -> Self::Root {
+        gtk::Box::builder()
+            .halign(gtk::Align::Center)
+            .valign(gtk::Align::Center)
+            .vexpand(true)
+            .spacing(32)
+            .build()
+    }
+
+    fn init(
+        params: Self::InitParams,
+        root: &Self::Root,
+        sender: &relm4::ComponentSender<Self>,
+    ) -> relm4::ComponentParts<Self> {
+        let widgets = PwdLoginWidget::new(root, &params, sender.input_sender());
+        let model = Self {
+            account: params.account,
+            password: params.password,
+            account_changed: false,
+        };
+
+        relm4::ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, message: Self::Input, sender: &relm4::ComponentSender<Self>) {
+        match message {
+            Input::Account(ac) => {
+                if let Ok(uin) = ac.parse::<i64>() {
+                    self.account.replace(uin);
+                    self.account_changed = true;
+                }
+            }
+            Input::Password(pwd) => {
+                self.password.replace(pwd);
+            }
+            Input::Login => sender.output(Output::Login {
+                account: self.account.unwrap(),
+                pwd: self.password.clone().unwrap(),
+            }),
+        }
+    }
+
+    fn update_view(&self, widgets: &mut Self::Widgets, _sender: &relm4::ComponentSender<Self>) {
+        widgets.account.set_text(
+            &self
+                .account
+                .map(|a| a.to_string())
+                .unwrap_or_else(String::new),
+        );
+
+        widgets.pwd.set_text(
+            Into::<Option<&String>>::into(&self.password)
+                .map(|s| s.as_str())
+                .unwrap_or(""),
+        );
+
+        if self.account.is_some() && self.password.is_some() {
+            widgets.login_btn.set_visible(true);
+        }
+
+        if self.account_changed {
+            widgets
+                .avatar
+                .set_custom_image(Option::<&'static Paintable>::None);
+        }
+    }
+}

--- a/libs/widgets/src/pwd_login/component.rs
+++ b/libs/widgets/src/pwd_login/component.rs
@@ -11,6 +11,7 @@ pub struct PasswordLoginModel {
     account_state: State,
     account: Option<i64>,
     password: PwdEntry,
+    avatar: Option<Paintable>,
 }
 
 impl relm4::SimpleComponent for PasswordLoginModel {
@@ -59,6 +60,7 @@ impl relm4::SimpleComponent for PasswordLoginModel {
             password: pwd,
             account_changed: false,
             account_state: State::NoChange,
+            avatar: None,
         };
 
         relm4::ComponentParts { model, widgets }
@@ -100,7 +102,7 @@ impl relm4::SimpleComponent for PasswordLoginModel {
                 (PwdEntry::Token(token), _) => sender.output(Output::TokenLogin(token)),
                 (_, _) => sender.output(Output::EnableLogin(false)),
             },
-            Input::Avatar(_) => todo!(),
+            Input::Avatar(pic) => self.avatar = pic,
         }
     }
 
@@ -127,5 +129,9 @@ impl relm4::SimpleComponent for PasswordLoginModel {
                 .avatar
                 .set_custom_image(Option::<&'static Paintable>::None);
         }
+
+        widgets
+            .avatar
+            .set_custom_image(Into::<Option<&Paintable>>::into(&self.avatar));
     }
 }

--- a/libs/widgets/src/pwd_login/component.rs
+++ b/libs/widgets/src/pwd_login/component.rs
@@ -30,10 +30,11 @@ impl relm4::SimpleComponent for PasswordLoginModel {
 
     fn init_root() -> Self::Root {
         gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
             .halign(gtk::Align::Center)
             .valign(gtk::Align::Center)
             .vexpand(true)
-            .spacing(32)
+            .spacing(10)
             .build()
     }
 

--- a/libs/widgets/src/pwd_login/component.rs
+++ b/libs/widgets/src/pwd_login/component.rs
@@ -27,11 +27,11 @@ impl relm4::SimpleComponent for PasswordLoginModel {
 
     fn init_root() -> Self::Root {
         gtk::Box::builder()
-            .orientation(gtk::Orientation::Vertical)
+            .orientation(gtk::Orientation::Horizontal)
             .halign(gtk::Align::Center)
             .valign(gtk::Align::Center)
             .vexpand(true)
-            .spacing(12)
+            .spacing(32)
             .build()
     }
 

--- a/libs/widgets/src/pwd_login/component.rs
+++ b/libs/widgets/src/pwd_login/component.rs
@@ -39,6 +39,13 @@ impl relm4::SimpleComponent for PasswordLoginModel {
         root: &Self::Root,
         sender: &relm4::ComponentSender<Self>,
     ) -> relm4::ComponentParts<Self> {
+        sender.output(Output::EnableLogin(
+            params.account.is_some() && params.token.is_some(),
+        ));
+        if params.auto_login {
+            sender.input(Input::Login);
+        }
+
         let widgets =
             PwdLoginWidget::new(root, &params, sender.input_sender(), sender.output_sender());
 

--- a/libs/widgets/src/pwd_login/component.rs
+++ b/libs/widgets/src/pwd_login/component.rs
@@ -34,7 +34,7 @@ impl relm4::SimpleComponent for PasswordLoginModel {
             .halign(gtk::Align::Center)
             .valign(gtk::Align::Center)
             .vexpand(true)
-            .spacing(10)
+            .spacing(12)
             .build()
     }
 

--- a/libs/widgets/src/pwd_login/component.rs
+++ b/libs/widgets/src/pwd_login/component.rs
@@ -15,7 +15,6 @@ pub struct PasswordLoginModel {
     account_state: State,
     account: Option<i64>,
     password: Option<String>,
-    
 }
 
 impl relm4::SimpleComponent for PasswordLoginModel {

--- a/libs/widgets/src/pwd_login/component.rs
+++ b/libs/widgets/src/pwd_login/component.rs
@@ -1,8 +1,4 @@
-use relm4::gtk::{
-    self,
-    gdk::Paintable,
-    traits::{EditableExt, WidgetExt},
-};
+use relm4::gtk::{self, gdk::Paintable, traits::EditableExt};
 
 use super::{
     payloads::{Input, Output, Payload, State},
@@ -43,7 +39,8 @@ impl relm4::SimpleComponent for PasswordLoginModel {
         root: &Self::Root,
         sender: &relm4::ComponentSender<Self>,
     ) -> relm4::ComponentParts<Self> {
-        let widgets = PwdLoginWidget::new(root, &params, sender.input_sender());
+        let widgets =
+            PwdLoginWidget::new(root, &params, sender.input_sender(), sender.output_sender());
         let model = Self {
             account: params.account,
             password: params.password,
@@ -86,7 +83,7 @@ impl relm4::SimpleComponent for PasswordLoginModel {
         }
     }
 
-    fn update_view(&self, widgets: &mut Self::Widgets, _sender: &relm4::ComponentSender<Self>) {
+    fn update_view(&self, widgets: &mut Self::Widgets, sender: &relm4::ComponentSender<Self>) {
         if let State::Update = self.account_state {
             widgets.account.set_text(
                 &self
@@ -96,9 +93,9 @@ impl relm4::SimpleComponent for PasswordLoginModel {
             );
         }
 
-        widgets
-            .login_btn
-            .set_sensitive(self.account.is_some() && self.password.is_some());
+        sender.output(Output::EnableLogin(
+            self.account.is_some() && self.password.is_some(),
+        ));
 
         if self.account_changed {
             widgets

--- a/libs/widgets/src/pwd_login/component.rs
+++ b/libs/widgets/src/pwd_login/component.rs
@@ -60,7 +60,7 @@ impl relm4::SimpleComponent for PasswordLoginModel {
             password: pwd,
             account_changed: false,
             account_state: State::NoChange,
-            avatar: None,
+            avatar: params.avatar,
         };
 
         relm4::ComponentParts { model, widgets }

--- a/libs/widgets/src/pwd_login/component.rs
+++ b/libs/widgets/src/pwd_login/component.rs
@@ -88,7 +88,7 @@ impl relm4::SimpleComponent for PasswordLoginModel {
             }
             Input::Login => match (self.password.clone(), self.account) {
                 (PwdEntry::Password(pwd), Some(account)) => {
-                    sender.output(Output::Login { account, pwd: pwd })
+                    sender.output(Output::Login { account, pwd })
                 }
                 (PwdEntry::Token(token), _) => sender.output(Output::TokenLogin(token)),
                 (_, _) => sender.output(Output::EnableLogin(false)),

--- a/libs/widgets/src/pwd_login/mod.rs
+++ b/libs/widgets/src/pwd_login/mod.rs
@@ -1,0 +1,10 @@
+mod component;
+mod payloads;
+mod widgets;
+
+pub use component::PasswordLoginModel;
+pub use payloads::{Input, Output, Payload};
+
+pub use widgets::PwdLoginWidget;
+
+pub type PasswordLogin = relm4::Controller<PasswordLoginModel>;

--- a/libs/widgets/src/pwd_login/payloads.rs
+++ b/libs/widgets/src/pwd_login/payloads.rs
@@ -1,4 +1,5 @@
 use relm4::gtk::gdk::Paintable;
+use ricq::client::Token;
 
 pub enum Input {
     Account(String),
@@ -9,6 +10,7 @@ pub enum Input {
 
 pub enum Output {
     Login { account: i64, pwd: String },
+    TokenLogin(Token),
     EnableLogin(bool),
 }
 
@@ -18,9 +20,25 @@ pub(super) enum State {
     Update,
 }
 
+#[derive(Debug, Clone)]
+pub(super) enum PwdEntry {
+    None,
+    Token(Token),
+    Password(String),
+}
+
 #[derive(Debug, Default)]
 pub struct Payload {
     pub account: Option<i64>,
-    pub password: Option<String>,
+    pub token: Option<Token>,
     pub avatar: Option<Paintable>,
+}
+
+impl PwdEntry {
+    pub(super) fn is_some(&self) -> bool {
+        match self {
+            PwdEntry::None => false,
+            _ => true,
+        }
+    }
 }

--- a/libs/widgets/src/pwd_login/payloads.rs
+++ b/libs/widgets/src/pwd_login/payloads.rs
@@ -22,4 +22,5 @@ pub struct Payload {
     pub account: Option<i64>,
     pub password: Option<String>,
     pub avatar: Option<Paintable>,
+    pub icon_name: &'static str,
 }

--- a/libs/widgets/src/pwd_login/payloads.rs
+++ b/libs/widgets/src/pwd_login/payloads.rs
@@ -9,6 +9,7 @@ pub enum Input {
 
 pub enum Output {
     Login { account: i64, pwd: String },
+    EnableLogin(bool)
 }
 
 #[derive(Debug)]
@@ -22,5 +23,4 @@ pub struct Payload {
     pub account: Option<i64>,
     pub password: Option<String>,
     pub avatar: Option<Paintable>,
-    pub icon_name: &'static str,
 }

--- a/libs/widgets/src/pwd_login/payloads.rs
+++ b/libs/widgets/src/pwd_login/payloads.rs
@@ -36,9 +36,6 @@ pub struct Payload {
 
 impl PwdEntry {
     pub(super) fn is_some(&self) -> bool {
-        match self {
-            PwdEntry::None => false,
-            _ => true,
-        }
+        !matches!(self, PwdEntry::None)
     }
 }

--- a/libs/widgets/src/pwd_login/payloads.rs
+++ b/libs/widgets/src/pwd_login/payloads.rs
@@ -3,16 +3,23 @@ use relm4::gtk::gdk::Paintable;
 pub enum Input {
     Account(String),
     Password(String),
-    Login
+    Login,
+    Avatar(Option<Paintable>)
 }
 
 pub enum Output {
     Login { account: i64, pwd: String },
 }
 
-#[derive(Debug, typed_builder::TypedBuilder)]
+#[derive(Debug)]
+pub(super) enum State{
+    NoChange,
+    Update
+}
+
+#[derive(Debug, Default)]
 pub struct Payload {
-    pub(super) account: Option<i64>,
-    pub(super) password: Option<String>,
-    pub(super) avatar : Option<Paintable>
+    pub account: Option<i64>,
+    pub password: Option<String>,
+    pub avatar: Option<Paintable>,
 }

--- a/libs/widgets/src/pwd_login/payloads.rs
+++ b/libs/widgets/src/pwd_login/payloads.rs
@@ -4,7 +4,7 @@ pub enum Input {
     Account(String),
     Password(String),
     Login,
-    Avatar(Option<Paintable>)
+    Avatar(Option<Paintable>),
 }
 
 pub enum Output {
@@ -12,9 +12,9 @@ pub enum Output {
 }
 
 #[derive(Debug)]
-pub(super) enum State{
+pub(super) enum State {
     NoChange,
-    Update
+    Update,
 }
 
 #[derive(Debug, Default)]

--- a/libs/widgets/src/pwd_login/payloads.rs
+++ b/libs/widgets/src/pwd_login/payloads.rs
@@ -1,0 +1,18 @@
+use relm4::gtk::gdk::Paintable;
+
+pub enum Input {
+    Account(String),
+    Password(String),
+    Login
+}
+
+pub enum Output {
+    Login { account: i64, pwd: String },
+}
+
+#[derive(Debug, typed_builder::TypedBuilder)]
+pub struct Payload {
+    pub(super) account: Option<i64>,
+    pub(super) password: Option<String>,
+    pub(super) avatar : Option<Paintable>
+}

--- a/libs/widgets/src/pwd_login/payloads.rs
+++ b/libs/widgets/src/pwd_login/payloads.rs
@@ -12,6 +12,8 @@ pub enum Output {
     Login { account: i64, pwd: String },
     TokenLogin(Token),
     EnableLogin(bool),
+    RememberPwd(bool),
+    AutoLogin(bool),
 }
 
 #[derive(Debug)]
@@ -32,6 +34,8 @@ pub struct Payload {
     pub account: Option<i64>,
     pub token: Option<Token>,
     pub avatar: Option<Paintable>,
+    pub remember_pwd: bool,
+    pub auto_login: bool,
 }
 
 impl PwdEntry {

--- a/libs/widgets/src/pwd_login/payloads.rs
+++ b/libs/widgets/src/pwd_login/payloads.rs
@@ -9,7 +9,7 @@ pub enum Input {
 
 pub enum Output {
     Login { account: i64, pwd: String },
-    EnableLogin(bool)
+    EnableLogin(bool),
 }
 
 #[derive(Debug)]

--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -6,7 +6,7 @@ use relm4::{
     gtk::{
         self,
         prelude::EntryBufferExtManual,
-        traits::{BoxExt, EditableExt, EntryExt},
+        traits::{BoxExt, CheckButtonExt, EditableExt, EntryExt},
         Align, CheckButton, Entry, EntryBuffer, PasswordEntry,
     },
     Sender,
@@ -95,18 +95,24 @@ impl PwdLoginWidget {
             .build();
 
         let remember_pwd = gtk::CheckButton::builder()
+            .active(payload.remember_pwd)
             .label("Remember Password")
-            .sensitive(false)
             .build();
+
+        let t_sender = output.clone();
+        remember_pwd.connect_toggled(move |this| {
+            t_sender.send(Output::RememberPwd(this.is_active()));
+        });
 
         let auto_login = gtk::CheckButton::builder()
             .label("Auto Login")
-            .sensitive(false)
+            .active(payload.auto_login)
             .build();
 
-        output.send(Output::EnableLogin(
-            payload.account.is_some() && payload.token.is_some(),
-        ));
+        let t_sender = output.clone();
+        auto_login.connect_toggled(move |this| {
+            t_sender.send(Output::AutoLogin(this.is_active()));
+        });
 
         root.append(&input_area);
         input_area.append(&avatar);

--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -7,7 +7,7 @@ use relm4::{
         self,
         prelude::EntryBufferExtManual,
         traits::{BoxExt, ButtonExt, EditableExt, EntryExt},
-        Align, Button, Entry, EntryBuffer, PasswordEntry,
+        Align, Button, CheckButton, Entry, EntryBuffer, PasswordEntry,
     },
     Sender,
 };
@@ -15,17 +15,31 @@ use relm4::{
 use super::payloads::{Input, Payload};
 #[derive(Debug)]
 pub struct PwdLoginWidget {
+    _input_area: gtk::Box,
     pub(super) avatar: Avatar,
     _group: PreferencesGroup,
     _account_row: ActionRow,
     pub(super) account: Entry,
     _pwd_row: ActionRow,
     pub(super) _pwd: PasswordEntry,
+    _op_box: gtk::Box,
+    _cfg_box: gtk::Box,
+    pub(super) _remember_pwd: CheckButton,
+    pub(super) _auto_login: CheckButton,
+
     pub(super) login_btn: Button,
 }
 
 impl PwdLoginWidget {
     pub(super) fn new(root: &gtk::Box, payload: &Payload, sender: &Sender<Input>) -> Self {
+        let input_area = gtk::Box::builder()
+            .orientation(gtk::Orientation::Horizontal)
+            .halign(gtk::Align::Center)
+            .valign(gtk::Align::Center)
+            .vexpand(true)
+            .spacing(32)
+            .build();
+
         let avatar = Avatar::builder().size(96).build();
 
         if let Some(ref a) = payload.avatar {
@@ -65,21 +79,46 @@ impl PwdLoginWidget {
         if let Some(ref p) = payload.password {
             pwd.set_text(p);
         }
-
         let t_sender = sender.clone();
         pwd.connect_changed(move |entry| t_sender.send(Input::Password(entry.text().to_string())));
 
+        let op_box = gtk::Box::builder()
+            .orientation(gtk::Orientation::Horizontal)
+            .halign(Align::End)
+            .spacing(5)
+            .vexpand(true)
+            .build();
+
+        let cfg_box = gtk::Box::builder()
+            .orientation(gtk::Orientation::Horizontal)
+            .valign(Align::Center)
+            .halign(Align::Center)
+            .spacing(5)
+            .build();
+
+        let remember_pwd = gtk::CheckButton::builder()
+            .label("remember password")
+            .sensitive(false)
+            .build();
+
+        let auto_login = gtk::CheckButton::builder()
+            .label("auto login")
+            .sensitive(false)
+            .build();
+
         let login_btn = Button::builder()
-            .label("Log in")
+            .icon_name(payload.icon_name)
+            .hexpand_set(true)
             .sensitive(payload.account.is_some() && payload.password.is_some())
             .build();
 
         let t_sender = sender.clone();
         login_btn.connect_clicked(move |_| t_sender.send(Input::Login));
 
-        root.append(&avatar);
+        root.append(&input_area);
+        input_area.append(&avatar);
 
-        root.append(&_group);
+        input_area.append(&_group);
 
         _group.add(&_account_row);
         _account_row.add_suffix(&account);
@@ -87,7 +126,11 @@ impl PwdLoginWidget {
         _group.add(&_pwd_row);
         _pwd_row.add_suffix(&pwd);
 
-        root.append(&login_btn);
+        root.append(&op_box);
+        op_box.append(&cfg_box);
+        cfg_box.append(&remember_pwd);
+        cfg_box.append(&auto_login);
+        op_box.append(&login_btn);
 
         Self {
             avatar,
@@ -97,6 +140,11 @@ impl PwdLoginWidget {
             _pwd_row,
             _pwd: pwd,
             login_btn,
+            _input_area: input_area,
+            _op_box: op_box,
+            _cfg_box: cfg_box,
+            _remember_pwd: remember_pwd,
+            _auto_login: auto_login,
         }
     }
 }

--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -78,6 +78,7 @@ impl PwdLoginWidget {
         let pwd = PasswordEntry::builder()
             .valign(Align::Center)
             .show_peek_icon(true)
+            .activates_default(true)
             .placeholder_text("QQ password")
             .build();
 
@@ -86,6 +87,9 @@ impl PwdLoginWidget {
         }
         let t_sender = sender.clone();
         pwd.connect_changed(move |entry| t_sender.send(Input::Password(entry.text().to_string())));
+
+        let t_sender = sender.clone();
+        pwd.connect_activate(move |_| t_sender.send(Input::Login));
 
         let cfg_box = gtk::Box::builder()
             .orientation(gtk::Orientation::Horizontal)
@@ -106,6 +110,7 @@ impl PwdLoginWidget {
 
         let auto_login = gtk::CheckButton::builder()
             .label("Auto Login")
+            .sensitive(false)
             .active(payload.auto_login)
             .build();
 

--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -7,7 +7,7 @@ use relm4::{
         self,
         prelude::EntryBufferExtManual,
         traits::{BoxExt, ButtonExt, EditableExt, EntryExt},
-        Align, Button, Entry, PasswordEntry, EntryBuffer,
+        Align, Button, Entry, EntryBuffer, PasswordEntry,
     },
     Sender,
 };

--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -85,7 +85,7 @@ impl PwdLoginWidget {
         let op_box = gtk::Box::builder()
             .orientation(gtk::Orientation::Horizontal)
             .halign(Align::End)
-            .spacing(5)
+            .spacing(24)
             .vexpand(true)
             .build();
 
@@ -93,7 +93,7 @@ impl PwdLoginWidget {
             .orientation(gtk::Orientation::Horizontal)
             .valign(Align::Center)
             .halign(Align::Center)
-            .spacing(5)
+            .spacing(8)
             .build();
 
         let remember_pwd = gtk::CheckButton::builder()

--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -38,11 +38,11 @@ impl PwdLoginWidget {
         output: &Sender<Output>,
     ) -> Self {
         let input_area = gtk::Box::builder()
-            .orientation(gtk::Orientation::Horizontal)
+            .orientation(gtk::Orientation::Vertical)
             .halign(gtk::Align::Center)
             .valign(gtk::Align::Center)
             .vexpand(true)
-            .spacing(32)
+            .spacing(12)
             .build();
 
         let avatar = Avatar::builder().size(96).build();
@@ -51,6 +51,7 @@ impl PwdLoginWidget {
             avatar.set_custom_image(Some(a));
         }
 
+        
         let _group = PreferencesGroup::new();
         let _account_row = ActionRow::builder()
             .title("Account  ")
@@ -91,10 +92,10 @@ impl PwdLoginWidget {
         let t_sender = sender.clone();
         pwd.connect_activate(move |_| t_sender.send(Input::Login));
 
-        let cfg_box = gtk::Box::builder()
+        let edit_box = gtk::Box::builder()
             .orientation(gtk::Orientation::Horizontal)
             .valign(Align::Center)
-            .halign(Align::End)
+            .halign(Align::Center)
             .spacing(8)
             .build();
 
@@ -119,20 +120,21 @@ impl PwdLoginWidget {
             t_sender.send(Output::AutoLogin(this.is_active()));
         });
 
+        root.append(&avatar);
         root.append(&input_area);
-        input_area.append(&avatar);
 
         input_area.append(&_group);
-
+        
         _group.add(&_account_row);
         _account_row.add_suffix(&account);
-
+        
         _group.add(&_pwd_row);
         _pwd_row.add_suffix(&pwd);
+        
+        input_area.append(&edit_box);
 
-        root.append(&cfg_box);
-        cfg_box.append(&remember_pwd);
-        cfg_box.append(&auto_login);
+        edit_box.append(&remember_pwd);
+        edit_box.append(&auto_login);
 
         Self {
             avatar,
@@ -142,7 +144,7 @@ impl PwdLoginWidget {
             _pwd_row,
             _pwd: pwd,
             _input_area: input_area,
-            _cfg_box: cfg_box,
+            _cfg_box: edit_box,
             _remember_pwd: remember_pwd,
             _auto_login: auto_login,
         }

--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -51,7 +51,6 @@ impl PwdLoginWidget {
             avatar.set_custom_image(Some(a));
         }
 
-        
         let _group = PreferencesGroup::new();
         let _account_row = ActionRow::builder()
             .title("Account  ")
@@ -124,13 +123,13 @@ impl PwdLoginWidget {
         root.append(&input_area);
 
         input_area.append(&_group);
-        
+
         _group.add(&_account_row);
         _account_row.add_suffix(&account);
-        
+
         _group.add(&_pwd_row);
         _pwd_row.add_suffix(&pwd);
-        
+
         input_area.append(&edit_box);
 
         edit_box.append(&remember_pwd);

--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -1,0 +1,99 @@
+use relm4::{
+    adw::{
+        traits::{ActionRowExt, PreferencesGroupExt},
+        ActionRow, Avatar, PreferencesGroup,
+    },
+    gtk::{
+        self,
+        prelude::EntryBufferExtManual,
+        traits::{BoxExt, ButtonExt, EditableExt, EntryExt},
+        Align, Button, Entry, PasswordEntry,
+    },
+    Sender,
+};
+
+use super::payloads::{Input, Payload};
+
+pub struct PwdLoginWidget {
+    pub(super) avatar: Avatar,
+    _group: PreferencesGroup,
+    _account_row: ActionRow,
+    pub(super) account: Entry,
+    _pwd_row: ActionRow,
+    pub(super) pwd: PasswordEntry,
+    pub(super) login_btn: Button,
+}
+
+impl PwdLoginWidget {
+    pub(super) fn new(root: &gtk::Box, payload: &Payload, sender: &Sender<Input>) -> Self {
+        let avatar = Avatar::builder().size(96).build();
+
+        if let Some(ref a) = payload.avatar {
+            avatar.set_custom_image(Some(a));
+        }
+
+        let _group = PreferencesGroup::new();
+        let _account_row = ActionRow::builder()
+            .title("Account  ")
+            .focusable(false)
+            .build();
+
+        let account = Entry::builder()
+            .valign(Align::Center)
+            .placeholder_text("Please input your QQ account ")
+            .build();
+
+        if let Some(uin) = payload.account {
+            account.buffer().set_text(&uin.to_string())
+        }
+
+        let t_sender = sender.clone();
+        account.connect_changed(move |entry| t_sender.send(Input::Account(entry.buffer().text())));
+
+        let _pwd_row = ActionRow::builder()
+            .title("Password")
+            .focusable(false)
+            .build();
+
+        let pwd = PasswordEntry::builder()
+            .valign(Align::Center)
+            .placeholder_text("Please input your QQ password")
+            .build();
+
+        if let Some(ref p) = payload.password {
+            pwd.set_text(p);
+        }
+
+        let t_sender = sender.clone();
+        pwd.connect_changed(move |entry| t_sender.send(Input::Password(entry.text().to_string())));
+
+        let login_btn = Button::builder().label("Log in")
+        .visible(false)
+        .build();
+
+        let t_sender = sender.clone();
+        login_btn.connect_clicked(move |_| t_sender.send(Input::Login));
+
+        root.append(&avatar);
+
+        root.append(&_group);
+
+        _group.add(&_account_row);
+        _account_row.add_suffix(&account);
+
+        _group.add(&_pwd_row);
+        _pwd_row.add_suffix(&pwd);
+
+        root.append(&login_btn);
+
+        Self {
+            avatar,
+            _group,
+            _account_row,
+            account,
+            _pwd_row,
+            pwd,
+            login_btn,
+        }
+    }
+}

--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -81,8 +81,8 @@ impl PwdLoginWidget {
             .placeholder_text("QQ password")
             .build();
 
-        if let Some(ref p) = payload.password {
-            pwd.set_text(p);
+        if payload.token.is_some() {
+            pwd.set_text("0123456789");
         }
         let t_sender = sender.clone();
         pwd.connect_changed(move |entry| t_sender.send(Input::Password(entry.text().to_string())));
@@ -105,7 +105,7 @@ impl PwdLoginWidget {
             .build();
 
         output.send(Output::EnableLogin(
-            payload.account.is_some() && payload.password.is_some(),
+            payload.account.is_some() && payload.token.is_some(),
         ));
 
         root.append(&input_area);

--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -7,20 +7,20 @@ use relm4::{
         self,
         prelude::EntryBufferExtManual,
         traits::{BoxExt, ButtonExt, EditableExt, EntryExt},
-        Align, Button, Entry, PasswordEntry,
+        Align, Button, Entry, PasswordEntry, EntryBuffer,
     },
     Sender,
 };
 
 use super::payloads::{Input, Payload};
-
+#[derive(Debug)]
 pub struct PwdLoginWidget {
     pub(super) avatar: Avatar,
     _group: PreferencesGroup,
     _account_row: ActionRow,
     pub(super) account: Entry,
     _pwd_row: ActionRow,
-    pub(super) pwd: PasswordEntry,
+    pub(super) _pwd: PasswordEntry,
     pub(super) login_btn: Button,
 }
 
@@ -40,11 +40,12 @@ impl PwdLoginWidget {
 
         let account = Entry::builder()
             .valign(Align::Center)
-            .placeholder_text("Please input your QQ account ")
+            .placeholder_text("QQ account")
             .build();
 
         if let Some(uin) = payload.account {
-            account.buffer().set_text(&uin.to_string())
+            let buf = EntryBuffer::new(Some(&uin.to_string()));
+            account.set_buffer(&buf);
         }
 
         let t_sender = sender.clone();
@@ -57,7 +58,8 @@ impl PwdLoginWidget {
 
         let pwd = PasswordEntry::builder()
             .valign(Align::Center)
-            .placeholder_text("Please input your QQ password")
+            .show_peek_icon(true)
+            .placeholder_text("QQ password")
             .build();
 
         if let Some(ref p) = payload.password {
@@ -67,9 +69,10 @@ impl PwdLoginWidget {
         let t_sender = sender.clone();
         pwd.connect_changed(move |entry| t_sender.send(Input::Password(entry.text().to_string())));
 
-        let login_btn = Button::builder().label("Log in")
-        .visible(false)
-        .build();
+        let login_btn = Button::builder()
+            .label("Log in")
+            .sensitive(payload.account.is_some() && payload.password.is_some())
+            .build();
 
         let t_sender = sender.clone();
         login_btn.connect_clicked(move |_| t_sender.send(Input::Login));
@@ -92,7 +95,7 @@ impl PwdLoginWidget {
             _account_row,
             account,
             _pwd_row,
-            pwd,
+            _pwd: pwd,
             login_btn,
         }
     }

--- a/src/app/login/captcha/mod.rs
+++ b/src/app/login/captcha/mod.rs
@@ -199,13 +199,7 @@ impl Component for CaptchaModel {
 impl CaptchaModel {
     async fn submit_ticket(self, sender: ComponentSender<CaptchaModel>) {
         match self.client.submit_ticket(&self.ticket).await {
-            Ok(res) => {
-                handle_login_response(
-                    res,
-                    self.client.clone(),
-                )
-                .await
-            }
+            Ok(res) => handle_login_response(res, self.client.clone()).await,
             Err(err) => {
                 sender.output(LoginPageMsg::LoginFailed(err.to_string()));
             }

--- a/src/app/login/captcha/mod.rs
+++ b/src/app/login/captcha/mod.rs
@@ -198,7 +198,7 @@ impl Component for CaptchaModel {
 impl CaptchaModel {
     async fn submit_ticket(self, sender: ComponentSender<CaptchaModel>) {
         match self.client.submit_ticket(&self.ticket).await {
-            Ok(res) => sender.output(LoginPageMsg::LoginRespond(res.into(), self.client.clone())),
+            Ok(res) => sender.output(LoginPageMsg::LoginRespond(res.into())),
             Err(err) => {
                 sender.output(LoginPageMsg::LoginFailed(err.to_string()));
             }

--- a/src/app/login/captcha/mod.rs
+++ b/src/app/login/captcha/mod.rs
@@ -199,7 +199,7 @@ impl Component for CaptchaModel {
 impl CaptchaModel {
     async fn submit_ticket(self, sender: ComponentSender<CaptchaModel>) {
         match self.client.submit_ticket(&self.ticket).await {
-            Ok(res) => handle_login_response(res, self.client.clone()).await,
+            Ok(res) => handle_login_response(&res, self.client.clone()).await,
             Err(err) => {
                 sender.output(LoginPageMsg::LoginFailed(err.to_string()));
             }

--- a/src/app/login/captcha/mod.rs
+++ b/src/app/login/captcha/mod.rs
@@ -13,7 +13,6 @@ use ricq::Client;
 use tokio::task;
 use widgets::link_copier::{self, LinkCopierModel};
 
-use super::service::handle_respond::handle_login_response;
 use super::LoginPageMsg;
 
 #[derive(Clone)]
@@ -199,7 +198,7 @@ impl Component for CaptchaModel {
 impl CaptchaModel {
     async fn submit_ticket(self, sender: ComponentSender<CaptchaModel>) {
         match self.client.submit_ticket(&self.ticket).await {
-            Ok(res) => handle_login_response(&res, self.client.clone()).await,
+            Ok(res) => sender.output(LoginPageMsg::LoginRespond(res.into(), self.client.clone())),
             Err(err) => {
                 sender.output(LoginPageMsg::LoginFailed(err.to_string()));
             }

--- a/src/app/login/captcha/mod.rs
+++ b/src/app/login/captcha/mod.rs
@@ -19,8 +19,6 @@ use super::LoginPageMsg;
 #[derive(Clone)]
 pub struct CaptchaModel {
     pub(crate) client: Arc<Client>,
-    pub(crate) account: i64,
-    pub(crate) password: String,
     pub(crate) ticket: String,
 }
 
@@ -36,8 +34,6 @@ pub enum Input {
 
 pub struct PayLoad {
     pub(crate) client: Arc<Client>,
-    pub(crate) account: i64,
-    pub(crate) password: String,
     pub(crate) window: Window,
     pub(crate) verify_url: String,
 }
@@ -172,8 +168,6 @@ impl Component for CaptchaModel {
         relm4::ComponentParts {
             model: CaptchaModel {
                 client: params.client,
-                account: params.account,
-                password: params.password,
                 ticket: String::new(),
             },
             widgets: CaptchaWidgets {
@@ -208,8 +202,6 @@ impl CaptchaModel {
             Ok(res) => {
                 handle_login_response(
                     res,
-                    self.account,
-                    self.password.clone(),
                     self.client.clone(),
                 )
                 .await

--- a/src/app/login/captcha/mod.rs
+++ b/src/app/login/captcha/mod.rs
@@ -13,7 +13,7 @@ use ricq::Client;
 use tokio::task;
 use widgets::link_copier::{self, LinkCopierModel};
 
-use super::service::handle_login_response;
+use super::service::handle_respond::handle_login_response;
 use super::LoginPageMsg;
 
 #[derive(Clone)]

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -72,7 +72,7 @@ impl SimpleComponent for LoginPageModel {
             .launch(Payload {
                 account: account.parse().ok(),
                 password: password.into(),
-                avatar: avatar,
+                avatar,
             })
             .forward(sender.input_sender(), |out| match out {
                 pwd_login::Output::Login { account, pwd } => LoginPageMsg::PwdLogin(account, pwd),

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -27,13 +27,11 @@ use crate::app::AppMessage;
 use crate::db::fs::{download_user_avatar_file, get_user_avatar_path};
 use crate::global::WINDOW;
 
+use self::service::pwd_login::login;
 use self::service::token::{token_login, LocalAccount};
-use self::service::{get_login_info, pwd_login::login};
 
 type SmsPhone = Option<String>;
 type VerifyUrl = String;
-type UserId = i64;
-type Password = String;
 
 pub static LOGIN_SENDER: OnceCell<ComponentSender<LoginPageModel>> = OnceCell::new();
 

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -5,24 +5,25 @@ mod service;
 use std::sync::Arc;
 
 use once_cell::sync::OnceCell;
+use relm4::gtk::gdk::Paintable;
 use relm4::{
     adw, gtk, Component, ComponentController, ComponentParts, ComponentSender, SimpleComponent,
 };
 
 use adw::prelude::*;
-use adw::{ActionRow, Avatar, HeaderBar, PreferencesGroup, Toast, ToastOverlay, Window};
-use gtk::gdk::Paintable;
+use adw::{HeaderBar, Toast, ToastOverlay, Window};
+
 use gtk::gdk_pixbuf::Pixbuf;
-use gtk::{Align, Box, Button, Entry, EntryBuffer, Label, MenuButton, Orientation, Picture};
+use gtk::{Box, Label, MenuButton, Orientation, Picture};
 
 use ricq::Client;
 use tokio::task;
+use widgets::pwd_login::{self, Input, PasswordLogin, PasswordLoginModel, Payload};
 
 use crate::actions::{AboutAction, ShortcutsAction};
 use crate::app::AppMessage;
 use crate::db::fs::{download_user_avatar_file, get_user_avatar_path};
 use crate::global::WINDOW;
-use crate::utils::avatar::loader::{AvatarLoader, User};
 
 use self::service::{get_login_info, login};
 
@@ -35,18 +36,17 @@ pub static LOGIN_SENDER: OnceCell<ComponentSender<LoginPageModel>> = OnceCell::n
 
 #[derive(Debug)]
 pub struct LoginPageModel {
-    account: String,
-    password: String,
-    is_login_button_enabled: bool,
+    // account: String,
+    // password: String,
+    // is_login_button_enabled: bool,
+    pwd_login: PasswordLogin,
     toast: Option<String>,
 }
 
 pub enum LoginPageMsg {
-    LoginStart,
+    Login(i64, String),
     LoginSuccessful,
     LoginFailed(String),
-    AccountChange(String),
-    PasswordChange(String),
     NeedCaptcha(String, Arc<Client>, UserId, Password),
     DeviceLock(VerifyUrl, SmsPhone),
     ConfirmVerification,
@@ -68,33 +68,22 @@ impl SimpleComponent for LoginPageModel {
         if LOGIN_SENDER.set(sender.clone()).is_err() {
             panic!("failed to initialize login sender");
         }
+        let (account, password) = get_login_info();
+        let avatar = load_avatar(account.parse().ok(), true);
+
+        let pwd_login = PasswordLoginModel::builder()
+            .launch(Payload {
+                account: account.parse().ok(),
+                password: password.into(),
+                avatar: avatar,
+            })
+            .forward(sender.input_sender(), |out| match out {
+                pwd_login::Output::Login { account, pwd } => LoginPageMsg::Login(account, pwd),
+            });
 
         let widgets = view_output!();
-
-        let (account, password) = get_login_info();
-        let account_buffer = EntryBuffer::new(Some(&account));
-        let password_buffer = EntryBuffer::new(Some(&password));
-        widgets.account_entry.set_buffer(&account_buffer);
-        widgets.password_entry.set_buffer(&password_buffer);
-
-        if let Ok(account) = account.parse::<i64>() {
-            let path = get_user_avatar_path(account);
-            if path.exists() {
-                if let Ok(pixbuf) = Pixbuf::from_file_at_size(path, 96, 96) {
-                    let image = Picture::for_pixbuf(&pixbuf);
-                    if let Some(paintable) = image.paintable() {
-                        widgets.avatar.set_custom_image(Some(&paintable));
-                    }
-                }
-            } else {
-                task::spawn(download_user_avatar_file(account));
-            }
-        }
-
         let model = LoginPageModel {
-            account,
-            password,
-            is_login_button_enabled: true,
+            pwd_login,
             toast: None,
         };
 
@@ -104,35 +93,15 @@ impl SimpleComponent for LoginPageModel {
     fn update(&mut self, msg: LoginPageMsg, sender: &ComponentSender<Self>) {
         use LoginPageMsg::*;
         match msg {
-            LoginStart => {
-                // Get the account
-                let account: i64 = match self.account.parse::<i64>() {
-                    Ok(account) => account,
-                    Err(_) => {
-                        self.toast = Some("Account is invalid".to_string());
-                        return;
-                    }
-                };
-                // Get the password
-                let password = if self.password.is_empty() {
-                    self.toast = Some("Password cannot be empty".to_string());
-                    return;
-                } else {
-                    self.password.to_string()
-                };
-
-                self.is_login_button_enabled = false;
-                task::spawn(login(account, password));
+            Login(uin, pwd) => {
+                task::spawn(login(uin, pwd));
             }
             LoginSuccessful => {
                 sender.output(AppMessage::LoginSuccessful);
             }
             LoginFailed(msg) => {
                 self.toast = Some(msg);
-                self.is_login_button_enabled = true;
             }
-            AccountChange(new_account) => self.account = new_account,
-            PasswordChange(new_password) => self.password = new_password,
             NeedCaptcha(verify_url, client, account, password) => {
                 sender.input(LoginPageMsg::LoginFailed(
                     "Need Captcha. See more in the pop-up window.".to_string(),
@@ -180,7 +149,7 @@ impl SimpleComponent for LoginPageModel {
                 window.present()
             }
             // TODO: proc follow operate
-            ConfirmVerification => sender.input(LoginStart),
+            ConfirmVerification => self.pwd_login.emit(Input::Login),
         }
     }
 
@@ -201,12 +170,6 @@ impl SimpleComponent for LoginPageModel {
                 set_title_widget = Some(&Label) {
                     set_label: "Login"
                 },
-                pack_end: go_next_button = &Button {
-                    set_icon_name: "go-next",
-                    connect_clicked[sender] => move |_| {
-                        sender.input(LoginPageMsg::LoginStart);
-                    },
-                },
                 pack_end = &MenuButton {
                     set_icon_name: "menu-symbolic",
                     set_menu_model: Some(&main_menu),
@@ -214,41 +177,7 @@ impl SimpleComponent for LoginPageModel {
             },
             #[name = "toast_overlay"]
             ToastOverlay {
-                set_child = Some(&Box) {
-                    set_halign: Align::Center,
-                    set_valign: Align::Center,
-                    set_vexpand: true,
-                    set_spacing: 32,
-                    #[name = "avatar"]
-                    Avatar {
-                        set_size: 96,
-                    },
-                    PreferencesGroup {
-                        add = &ActionRow {
-                            set_title: "Account",
-                            set_focusable: false,
-                            add_suffix: account_entry = &Entry {
-                                set_valign: Align::Center,
-                                set_placeholder_text: Some("Please input your QQ account "),
-                                connect_changed[sender] => move |e| {
-                                    sender.input(LoginPageMsg::AccountChange(e.buffer().text()));
-                                }
-                            },
-                        },
-                        add = &ActionRow {
-                            set_title: "Password",
-                            set_focusable: false,
-                            add_suffix: password_entry = &Entry {
-                                set_valign: Align::Center,
-                                set_placeholder_text: Some("Please input your QQ password"),
-                                set_visibility: false,
-                                connect_changed[sender] => move |e| {
-                                    sender.input(LoginPageMsg::PasswordChange(e.buffer().text()));
-                                }
-                            },
-                        },
-                    },
-                },
+                set_child : Some(pwd_login.widget()),
             }
         }
     }
@@ -257,20 +186,23 @@ impl SimpleComponent for LoginPageModel {
         if let Some(content) = &self.toast {
             widgets.toast_overlay.add_toast(&Toast::new(content));
         }
-        widgets
-            .go_next_button
-            .set_sensitive(self.is_login_button_enabled);
-
-        let paint = self
-            .account
-            .parse::<i64>()
-            .ok()
-            .and_then(|id| User::get_avatar_as_pixbuf(id, 96, 96).ok())
-            .map(|pix_buf| Picture::for_pixbuf(&pix_buf))
-            .and_then(|pic| pic.paintable());
-
-        widgets
-            .avatar
-            .set_custom_image(Into::<Option<&'_ Paintable>>::into(&paint));
     }
+}
+
+fn load_avatar(account: Option<i64>, auto_download: bool) -> Option<Paintable> {
+    account
+        .map(|uin| (uin, get_user_avatar_path(uin)))
+        .and_then(|(uin, path)| {
+            if path.exists() {
+                Some(path)
+            } else {
+                if auto_download {
+                    task::spawn(download_user_avatar_file(uin));
+                }
+                None
+            }
+        })
+        .and_then(|path| Pixbuf::from_file_at_size(path, 96, 96).ok())
+        .map(|pix| Picture::for_pixbuf(&pix))
+        .and_then(|pic| pic.paintable())
 }

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -170,6 +170,7 @@ impl SimpleComponent for LoginPageModel {
                 self.enable_btn = enable && self.sender.is_some();
             }
             StartLogin => {
+                self.enable_btn = false;
                 self.pwd_login.emit(Input::Login);
             }
             PwdLogin(uin, pwd) => {
@@ -184,6 +185,7 @@ impl SimpleComponent for LoginPageModel {
                 sender.output(AppMessage::LoginSuccessful);
             }
             LoginFailed(msg) => {
+                self.enable_btn = true;
                 *(self.toast.borrow_mut()) = Some(msg);
             }
             NeedCaptcha(verify_url, client) => {
@@ -229,7 +231,7 @@ impl SimpleComponent for LoginPageModel {
                 window.present()
             }
             // TODO: proc follow operate
-            ConfirmVerification => self.pwd_login.emit(Input::Login),
+            ConfirmVerification => sender.input(LoginPageMsg::StartLogin),
             LinkCopied => {
                 self.toast.borrow_mut().replace("Link Copied".into());
             }

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -73,6 +73,7 @@ impl SimpleComponent for LoginPageModel {
                 account: account.parse().ok(),
                 password: password.into(),
                 avatar,
+                icon_name: "go-next",
             })
             .forward(sender.input_sender(), |out| match out {
                 pwd_login::Output::Login { account, pwd } => LoginPageMsg::PwdLogin(account, pwd),

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -98,7 +98,7 @@ impl SimpleComponent for LoginPageModel {
         match msg {
             EnableLogin(enable) => {
                 self.enable_btn = enable;
-            },
+            }
             StartLogin => {
                 self.pwd_login.emit(Input::Login);
             }
@@ -203,7 +203,6 @@ impl SimpleComponent for LoginPageModel {
             widgets.toast_overlay.add_toast(&Toast::new(content));
         }
         widgets.login_btn.set_sensitive(self.enable_btn);
-        
     }
 }
 

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -299,11 +299,8 @@ impl LoginPageModel {
             REMEMBER_PWD.load(Ordering::Relaxed).to_string(),
         )
         .expect("Save cfg Error");
-        save_sql_config(
-            "auto_login",
-            AUTO_LOGIN.load(Ordering::Relaxed).to_string(),
-        )
-        .expect("Save cfg Error");
+        save_sql_config("auto_login", AUTO_LOGIN.load(Ordering::Relaxed).to_string())
+            .expect("Save cfg Error");
     }
 }
 

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -240,7 +240,7 @@ impl SimpleComponent for LoginPageModel {
 
     fn pre_view(&self, widgets: &mut Self::Widgets, sender: &ComponentSender<Self>) {
         if let Some(ref content) = self.toast.borrow_mut().take() {
-            widgets.toast_overlay.add_toast(&Toast::new(&content));
+            widgets.toast_overlay.add_toast(&Toast::new(content));
         }
         widgets.login_btn.set_sensitive(self.enable_btn);
     }
@@ -251,10 +251,9 @@ impl SimpleComponent for LoginPageModel {
 }
 
 impl LoginPageModel {
-    fn save_login_setting(&self){
+    fn save_login_setting(&self) {
         save_sql_config(&"remember_pwd", &self.remember_pwd.to_string()).expect("Save cfg Error");
         save_sql_config(&"auto_login", &self.auto_login.to_string()).expect("Save cfg Error");
-
     }
 }
 

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -37,7 +37,6 @@ use self::service::token::{token_login, LocalAccount};
 type SmsPhone = Option<String>;
 type VerifyUrl = String;
 
-
 #[derive(Debug)]
 pub struct LoginPageModel {
     pwd_login: PasswordLogin,
@@ -131,7 +130,9 @@ impl SimpleComponent for LoginPageModel {
         match msg {
             LoginRespond(boxed_login_resp, client) => {
                 let sender = sender.input_sender().clone();
-                tokio::spawn(async move { handle_login_response(&boxed_login_resp, client,sender).await });
+                tokio::spawn(async move {
+                    handle_login_response(&boxed_login_resp, client, &sender).await
+                });
             }
             RememberPwd(b) => {
                 self.remember_pwd = b;
@@ -141,7 +142,7 @@ impl SimpleComponent for LoginPageModel {
             }
             TokenLogin(token) => {
                 let sender = sender.input_sender().clone();
-                task::spawn(token_login(token, sender));
+                task::spawn(async move { token_login(token, &sender).await });
             }
             EnableLogin(enable) => {
                 self.enable_btn = enable;
@@ -151,7 +152,7 @@ impl SimpleComponent for LoginPageModel {
             }
             PwdLogin(uin, pwd) => {
                 let sender = sender.input_sender().clone();
-                task::spawn(login(uin, pwd, sender));
+                task::spawn(async move { login(uin, pwd, &sender).await });
             }
             LoginSuccessful => {
                 self.save_login_setting();

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -147,7 +147,7 @@ impl SimpleComponent for LoginPageModel {
                 client.start_handle();
             }
             LoginRespond(boxed_login_resp) => {
-                if let Some(ref sender) = self.sender {
+                if let Some(sender) = &mut self.sender {
                     sender.send(login_server::Input::LoginRespond(boxed_login_resp))
                 } else {
                     sender.input(LoginFailed("Client Not Init. Please Wait".into()));
@@ -160,7 +160,7 @@ impl SimpleComponent for LoginPageModel {
                 self.auto_login = b;
             }
             TokenLogin(token) => {
-                if let Some(ref sender) = self.sender {
+                if let Some(sender) = &mut self.sender {
                     sender.send(login_server::Input::Login(Login::Token(token.into())))
                 } else {
                     sender.input(LoginFailed("Client Not Init. Please Wait".into()));
@@ -174,7 +174,7 @@ impl SimpleComponent for LoginPageModel {
                 self.pwd_login.emit(Input::Login);
             }
             PwdLogin(uin, pwd) => {
-                if let Some(ref sender) = self.sender {
+                if let Some(sender) = &mut self.sender {
                     sender.send(login_server::Input::Login(Login::Pwd(uin, pwd)))
                 } else {
                     sender.input(LoginFailed("Client Not Init. Please Wait".into()));

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -36,15 +36,12 @@ pub static LOGIN_SENDER: OnceCell<ComponentSender<LoginPageModel>> = OnceCell::n
 
 #[derive(Debug)]
 pub struct LoginPageModel {
-    // account: String,
-    // password: String,
-    // is_login_button_enabled: bool,
     pwd_login: PasswordLogin,
     toast: Option<String>,
 }
 
 pub enum LoginPageMsg {
-    Login(i64, String),
+    PwdLogin(i64, String),
     LoginSuccessful,
     LoginFailed(String),
     NeedCaptcha(String, Arc<Client>, UserId, Password),
@@ -78,7 +75,7 @@ impl SimpleComponent for LoginPageModel {
                 avatar: avatar,
             })
             .forward(sender.input_sender(), |out| match out {
-                pwd_login::Output::Login { account, pwd } => LoginPageMsg::Login(account, pwd),
+                pwd_login::Output::Login { account, pwd } => LoginPageMsg::PwdLogin(account, pwd),
             });
 
         let widgets = view_output!();
@@ -93,7 +90,7 @@ impl SimpleComponent for LoginPageModel {
     fn update(&mut self, msg: LoginPageMsg, sender: &ComponentSender<Self>) {
         use LoginPageMsg::*;
         match msg {
-            Login(uin, pwd) => {
+            PwdLogin(uin, pwd) => {
                 task::spawn(login(uin, pwd));
             }
             LoginSuccessful => {

--- a/src/app/login/mod.rs
+++ b/src/app/login/mod.rs
@@ -26,7 +26,7 @@ use crate::app::AppMessage;
 use crate::db::fs::{download_user_avatar_file, get_user_avatar_path};
 use crate::global::WINDOW;
 
-use self::service::{get_login_info, login};
+use self::service::{get_login_info, pwd_login::login};
 
 type SmsPhone = Option<String>;
 type VerifyUrl = String;

--- a/src/app/login/service.rs
+++ b/src/app/login/service.rs
@@ -1,4 +1,3 @@
-
 use resource_loader::SyncLoadResource;
 use std::{io, sync::Arc};
 

--- a/src/app/login/service.rs
+++ b/src/app/login/service.rs
@@ -33,8 +33,6 @@ pub(crate) async fn init_client() -> io::Result<Arc<Client>> {
     Ok(client)
 }
 
-
-
 pub(crate) async fn finish_login(account: i64, password: String, client: Arc<Client>) {
     let sender = LOGIN_SENDER.get().unwrap();
 

--- a/src/app/login/service.rs
+++ b/src/app/login/service.rs
@@ -47,5 +47,5 @@ pub(crate) async fn finish_login(client: Arc<Client>, sender: &Sender<LoginPageM
     local.save_account(&sender);
 
     after_login(&client).await;
-    sender.send(LoginSuccessful);
+    sender.send(LoginSuccessful(client));
 }

--- a/src/app/login/service.rs
+++ b/src/app/login/service.rs
@@ -9,7 +9,6 @@ use tokio::{net::TcpStream, task};
 use crate::app::login::service::handle_respond::handle_login_response;
 use crate::app::login::service::token::LocalAccount;
 use crate::app::login::{LoginPageMsg, LOGIN_SENDER};
-use crate::db::sql::get_db;
 
 use crate::handler::{AppHandler, ACCOUNT, CLIENT};
 
@@ -49,27 +48,4 @@ pub(crate) async fn finish_login(client: Arc<Client>) {
 
     after_login(&client).await;
     sender.input(LoginSuccessful);
-}
-
-pub(crate) fn get_login_info() -> (String, String) {
-    let conn = get_db();
-    let mut stmt = conn
-        .prepare("SELECT value FROM configs where key='account'")
-        .unwrap();
-    let mut rows = stmt.query([]).unwrap();
-    let account = match rows.next().unwrap() {
-        Some(row) => row.get(0).unwrap(),
-        None => String::new(),
-    };
-
-    let mut stmt = conn
-        .prepare("SELECT value FROM configs where key='password'")
-        .unwrap();
-    let mut rows = stmt.query([]).unwrap();
-    let password = match rows.next().unwrap() {
-        Some(row) => row.get(0).unwrap(),
-        None => String::new(),
-    };
-
-    (account, password)
 }

--- a/src/app/login/service.rs
+++ b/src/app/login/service.rs
@@ -6,7 +6,6 @@ use qrcode_png::{Color, QrCode};
 use ricq::{ext::common::after_login, Client, LoginUnknownStatus};
 use tokio::{net::TcpStream, task};
 
-use crate::app::login::service::handle_respond::handle_login_response;
 use crate::app::login::service::token::LocalAccount;
 use crate::app::login::{LoginPageMsg, LOGIN_SENDER};
 

--- a/src/app/login/service.rs
+++ b/src/app/login/service.rs
@@ -44,7 +44,7 @@ pub(crate) async fn finish_login(client: Arc<Client>, sender: &Sender<LoginPageM
         panic!("falied to store account");
     };
 
-    local.save_account(&sender);
+    local.save_account(sender);
 
     after_login(&client).await;
     sender.send(LoginSuccessful(client));

--- a/src/app/login/service.rs
+++ b/src/app/login/service.rs
@@ -1,20 +1,21 @@
 use resource_loader::SyncLoadResource;
 use std::{io, sync::Arc};
 
-use qrcode_png::{Color, QrCode, QrCodeEcc};
+use qrcode_png::{Color, QrCode};
 
-use resource_loader::{AsyncCreatePath, CaptchaQrCode};
-use ricq::{
-    ext::common::after_login, Client, LoginDeviceLocked, LoginNeedCaptcha, LoginResponse,
-    LoginUnknownStatus,
-};
+use ricq::{ext::common::after_login, Client, LoginUnknownStatus};
 use rusqlite::params;
-use tokio::{fs, net::TcpStream, task};
+use tokio::{net::TcpStream, task};
 
+use crate::app::login::service::handle_respond::handle_login_response;
 use crate::app::login::{LoginPageMsg, LOGIN_SENDER};
 use crate::db::sql::get_db;
 
 use crate::handler::{AppHandler, ACCOUNT, CLIENT};
+
+pub(super) mod handle_respond;
+pub(super) mod pwd_login;
+pub mod token;
 
 pub(crate) async fn init_client() -> io::Result<Arc<Client>> {
     let client = Arc::new(Client::new(
@@ -32,102 +33,7 @@ pub(crate) async fn init_client() -> io::Result<Arc<Client>> {
     Ok(client)
 }
 
-pub(crate) async fn login(account: i64, password: String) {
-    use crate::app::login::LoginPageMsg::LoginFailed;
-    let sender = LOGIN_SENDER.get().unwrap();
 
-    let client = match init_client().await {
-        Ok(client) => client,
-        Err(err) => {
-            sender.input(LoginFailed(err.to_string()));
-            return;
-        }
-    };
-
-    let res = match client.password_login(account, &password).await {
-        Ok(res) => res,
-        Err(err) => {
-            sender.input(LoginFailed(err.to_string()));
-            return;
-        }
-    };
-    handle_login_response(res, account, password, client).await;
-}
-
-pub(crate) async fn handle_login_response(
-    res: LoginResponse,
-    account: i64,
-    password: String,
-    client: Arc<Client>,
-) {
-    let sender = LOGIN_SENDER.get().unwrap();
-
-    use LoginPageMsg::LoginFailed;
-    match res {
-        LoginResponse::Success(_) => {
-            finish_login(account, password, client).await;
-        }
-        LoginResponse::NeedCaptcha(LoginNeedCaptcha { verify_url, .. }) => {
-            // Get the captcha url qrcode image path
-            let path = match CaptchaQrCode::create_and_get_path_async().await {
-                Ok(path) => path,
-                Err(err) => {
-                    sender.input(LoginFailed(err.to_string()));
-                    return;
-                }
-            };
-
-            // Generate qrcode image
-            let verify_url = verify_url.unwrap();
-            let mut qrcode = QrCode::new(verify_url.clone(), QrCodeEcc::Low).unwrap();
-            qrcode.margin(10);
-            qrcode.zoom(5);
-
-            // Write the image
-            let buf = qrcode.generate(Color::Grayscale(0, 255)).unwrap();
-            if let Err(err) = fs::write(path, buf).await {
-                sender.input(LoginFailed(err.to_string()));
-                return;
-            };
-            sender.input(LoginPageMsg::NeedCaptcha(
-                verify_url,
-                client.clone(),
-                account,
-                password,
-            ));
-        }
-        LoginResponse::AccountFrozen => {
-            sender.input(LoginFailed("Account Frozen".to_string()));
-        }
-        LoginResponse::DeviceLocked(LoginDeviceLocked {
-            sms_phone,
-            verify_url,
-            ..
-        }) => {
-            sender.input(LoginFailed(
-                "Device Locked. See more in the pop-up window.".to_string(),
-            ));
-
-            sender.input(LoginPageMsg::DeviceLock(
-                verify_url.unwrap_or_else(|| "<unknown>".into()),
-                sms_phone,
-            ));
-        }
-        LoginResponse::TooManySMSRequest => {
-            sender.input(LoginFailed("Too Many SMS Request".to_string()));
-        }
-        LoginResponse::DeviceLockLogin(_) => {
-            if let Err(err) = client.device_lock_login().await {
-                sender.input(LoginFailed(err.to_string()));
-            } else {
-                finish_login(account, password, client).await;
-            }
-        }
-        LoginResponse::UnknownStatus(LoginUnknownStatus { message, .. }) => {
-            sender.input(LoginFailed(message));
-        }
-    }
-}
 
 pub(crate) async fn finish_login(account: i64, password: String, client: Arc<Client>) {
     let sender = LOGIN_SENDER.get().unwrap();

--- a/src/app/login/service/handle_respond.rs
+++ b/src/app/login/service/handle_respond.rs
@@ -11,7 +11,7 @@ use tokio::fs;
 pub(in crate::app) async fn handle_login_response(
     res: &LoginResponse,
     client: Arc<Client>,
-    sender: Sender<LoginPageMsg>,
+    sender: &Sender<LoginPageMsg>,
 ) {
     use LoginPageMsg::LoginFailed;
     match res {

--- a/src/app/login/service/handle_respond.rs
+++ b/src/app/login/service/handle_respond.rs
@@ -1,13 +1,13 @@
-use crate::app::login::service::LoginUnknownStatus;
-use ricq::LoginDeviceLocked;
 use crate::app::login::service::Color;
+use crate::app::login::service::LoginUnknownStatus;
 use crate::app::login::service::QrCode;
+use crate::app::login::{service::finish_login, Arc, LoginPageMsg, LOGIN_SENDER};
 use qrcode_png::QrCodeEcc;
 use resource_loader::AsyncCreatePath;
-use tokio::fs;
-use crate::app::login::{Arc, LOGIN_SENDER, LoginPageMsg, service::finish_login};
 use resource_loader::CaptchaQrCode;
-use ricq::{LoginResponse, Client, LoginNeedCaptcha};
+use ricq::LoginDeviceLocked;
+use ricq::{Client, LoginNeedCaptcha, LoginResponse};
+use tokio::fs;
 
 pub(in crate::app) async fn handle_login_response(
     res: LoginResponse,

--- a/src/app/login/service/handle_respond.rs
+++ b/src/app/login/service/handle_respond.rs
@@ -16,7 +16,7 @@ pub(in crate::app) async fn handle_login_response(
     use LoginPageMsg::LoginFailed;
     match res {
         LoginResponse::Success(_) => {
-            finish_login(Arc::clone(client), &sender).await;
+            finish_login(Arc::clone(client), sender).await;
         }
         LoginResponse::NeedCaptcha(LoginNeedCaptcha { verify_url, .. }) => {
             let verify_url = Into::<Option<&String>>::into(verify_url);
@@ -40,7 +40,10 @@ pub(in crate::app) async fn handle_login_response(
                     .await
                     .map_err(|err| err.to_string())?;
 
-                sender.send(LoginPageMsg::NeedCaptcha(verify_url.clone(), Arc::clone(client)));
+                sender.send(LoginPageMsg::NeedCaptcha(
+                    verify_url.clone(),
+                    Arc::clone(client),
+                ));
                 Result::<_, String>::Ok(())
             };
 
@@ -73,7 +76,7 @@ pub(in crate::app) async fn handle_login_response(
                 sender.send(LoginFailed(err.to_string()));
             }
             Ok(_) => {
-                finish_login(Arc::clone(client), &sender).await;
+                finish_login(Arc::clone(client), sender).await;
             }
         },
         LoginResponse::UnknownStatus(LoginUnknownStatus { message, .. }) => {

--- a/src/app/login/service/handle_respond.rs
+++ b/src/app/login/service/handle_respond.rs
@@ -9,7 +9,7 @@ use ricq::LoginDeviceLocked;
 use ricq::{Client, LoginNeedCaptcha, LoginResponse};
 use tokio::fs;
 
-pub(in crate::app) async fn handle_login_response(res: LoginResponse, client: Arc<Client>) {
+pub(in crate::app) async fn handle_login_response(res: &LoginResponse, client: Arc<Client>) {
     let sender = LOGIN_SENDER.get().unwrap();
 
     use LoginPageMsg::LoginFailed;
@@ -18,28 +18,37 @@ pub(in crate::app) async fn handle_login_response(res: LoginResponse, client: Ar
             finish_login(client).await;
         }
         LoginResponse::NeedCaptcha(LoginNeedCaptcha { verify_url, .. }) => {
-            // Get the captcha url qrcode image path
-            let path = match CaptchaQrCode::create_and_get_path_async().await {
-                Ok(path) => path,
-                Err(err) => {
-                    sender.input(LoginFailed(err.to_string()));
-                    return;
-                }
+            let verify_url = Into::<Option<&String>>::into(verify_url);
+            let operate = || async {
+                // Get the captcha url qrcode image path
+                let path = CaptchaQrCode::create_and_get_path_async()
+                    .await
+                    .map_err(|err| err.to_string())?;
+
+                // Generate qrcode image
+                let verify_url = verify_url.unwrap();
+                let qrcode = QrCode::new(&verify_url, QrCodeEcc::Low)
+                    .map_err(|err| err.to_string())?
+                    .margin(10)
+                    .zoom(5)
+                    .generate(Color::Grayscale(0, 255))
+                    .map_err(|err| err.to_string())?;
+
+                // Write the image
+                fs::write(path, qrcode)
+                    .await
+                    .map_err(|err| err.to_string())?;
+
+                sender.input(LoginPageMsg::NeedCaptcha(
+                    verify_url.clone(),
+                    client,
+                ));
+                Result::<_, String>::Ok(())
             };
 
-            // Generate qrcode image
-            let verify_url = verify_url.unwrap();
-            let mut qrcode = QrCode::new(verify_url.clone(), QrCodeEcc::Low).unwrap();
-            qrcode.margin(10);
-            qrcode.zoom(5);
-
-            // Write the image
-            let buf = qrcode.generate(Color::Grayscale(0, 255)).unwrap();
-            if let Err(err) = fs::write(path, buf).await {
-                sender.input(LoginFailed(err.to_string()));
-                return;
-            };
-            sender.input(LoginPageMsg::NeedCaptcha(verify_url, client.clone()));
+            if let Err(err) = operate().await {
+                sender.input(LoginFailed(err));
+            }
         }
         LoginResponse::AccountFrozen => {
             sender.input(LoginFailed("Account Frozen".to_string()));
@@ -54,22 +63,23 @@ pub(in crate::app) async fn handle_login_response(res: LoginResponse, client: Ar
             ));
 
             sender.input(LoginPageMsg::DeviceLock(
-                verify_url.unwrap_or_else(|| "<unknown>".into()),
-                sms_phone,
+                verify_url.clone().unwrap_or_else(|| "<unknown>".into()),
+                sms_phone.clone(),
             ));
         }
         LoginResponse::TooManySMSRequest => {
             sender.input(LoginFailed("Too Many SMS Request".to_string()));
         }
-        LoginResponse::DeviceLockLogin(_) => {
-            if let Err(err) = client.device_lock_login().await {
+        LoginResponse::DeviceLockLogin(_) => match client.device_lock_login().await {
+            Err(err) => {
                 sender.input(LoginFailed(err.to_string()));
-            } else {
+            }
+            Ok(_) => {
                 finish_login(client).await;
             }
-        }
+        },
         LoginResponse::UnknownStatus(LoginUnknownStatus { message, .. }) => {
-            sender.input(LoginFailed(message));
+            sender.input(LoginFailed(message.clone()));
         }
     }
 }

--- a/src/app/login/service/handle_respond.rs
+++ b/src/app/login/service/handle_respond.rs
@@ -9,10 +9,7 @@ use ricq::LoginDeviceLocked;
 use ricq::{Client, LoginNeedCaptcha, LoginResponse};
 use tokio::fs;
 
-pub(in crate::app) async fn handle_login_response(
-    res: LoginResponse,
-    client: Arc<Client>,
-) {
+pub(in crate::app) async fn handle_login_response(res: LoginResponse, client: Arc<Client>) {
     let sender = LOGIN_SENDER.get().unwrap();
 
     use LoginPageMsg::LoginFailed;
@@ -42,10 +39,7 @@ pub(in crate::app) async fn handle_login_response(
                 sender.input(LoginFailed(err.to_string()));
                 return;
             };
-            sender.input(LoginPageMsg::NeedCaptcha(
-                verify_url,
-                client.clone(),
-            ));
+            sender.input(LoginPageMsg::NeedCaptcha(verify_url, client.clone()));
         }
         LoginResponse::AccountFrozen => {
             sender.input(LoginFailed("Account Frozen".to_string()));

--- a/src/app/login/service/handle_respond.rs
+++ b/src/app/login/service/handle_respond.rs
@@ -1,12 +1,10 @@
-use crate::app::login::service::Color;
-use crate::app::login::service::LoginUnknownStatus;
-use crate::app::login::service::QrCode;
-use crate::app::login::{service::finish_login, Arc, LoginPageMsg, LOGIN_SENDER};
+use crate::app::login::{
+    service::{finish_login, Color, LoginUnknownStatus, QrCode},
+    Arc, LoginPageMsg, LOGIN_SENDER,
+};
 use qrcode_png::QrCodeEcc;
-use resource_loader::AsyncCreatePath;
-use resource_loader::CaptchaQrCode;
-use ricq::LoginDeviceLocked;
-use ricq::{Client, LoginNeedCaptcha, LoginResponse};
+use resource_loader::{AsyncCreatePath, CaptchaQrCode};
+use ricq::{Client, LoginDeviceLocked, LoginNeedCaptcha, LoginResponse};
 use tokio::fs;
 
 pub(in crate::app) async fn handle_login_response(res: &LoginResponse, client: Arc<Client>) {
@@ -39,10 +37,7 @@ pub(in crate::app) async fn handle_login_response(res: &LoginResponse, client: A
                     .await
                     .map_err(|err| err.to_string())?;
 
-                sender.input(LoginPageMsg::NeedCaptcha(
-                    verify_url.clone(),
-                    client,
-                ));
+                sender.input(LoginPageMsg::NeedCaptcha(verify_url.clone(), client));
                 Result::<_, String>::Ok(())
             };
 

--- a/src/app/login/service/handle_respond.rs
+++ b/src/app/login/service/handle_respond.rs
@@ -1,0 +1,85 @@
+use crate::app::login::service::LoginUnknownStatus;
+use ricq::LoginDeviceLocked;
+use crate::app::login::service::Color;
+use crate::app::login::service::QrCode;
+use qrcode_png::QrCodeEcc;
+use resource_loader::AsyncCreatePath;
+use tokio::fs;
+use crate::app::login::{Arc, LOGIN_SENDER, LoginPageMsg, service::finish_login};
+use resource_loader::CaptchaQrCode;
+use ricq::{LoginResponse, Client, LoginNeedCaptcha};
+
+pub(in crate::app) async fn handle_login_response(
+    res: LoginResponse,
+    account: i64,
+    password: String,
+    client: Arc<Client>,
+) {
+    let sender = LOGIN_SENDER.get().unwrap();
+
+    use LoginPageMsg::LoginFailed;
+    match res {
+        LoginResponse::Success(_) => {
+            finish_login(account, password, client).await;
+        }
+        LoginResponse::NeedCaptcha(LoginNeedCaptcha { verify_url, .. }) => {
+            // Get the captcha url qrcode image path
+            let path = match CaptchaQrCode::create_and_get_path_async().await {
+                Ok(path) => path,
+                Err(err) => {
+                    sender.input(LoginFailed(err.to_string()));
+                    return;
+                }
+            };
+
+            // Generate qrcode image
+            let verify_url = verify_url.unwrap();
+            let mut qrcode = QrCode::new(verify_url.clone(), QrCodeEcc::Low).unwrap();
+            qrcode.margin(10);
+            qrcode.zoom(5);
+
+            // Write the image
+            let buf = qrcode.generate(Color::Grayscale(0, 255)).unwrap();
+            if let Err(err) = fs::write(path, buf).await {
+                sender.input(LoginFailed(err.to_string()));
+                return;
+            };
+            sender.input(LoginPageMsg::NeedCaptcha(
+                verify_url,
+                client.clone(),
+                account,
+                password,
+            ));
+        }
+        LoginResponse::AccountFrozen => {
+            sender.input(LoginFailed("Account Frozen".to_string()));
+        }
+        LoginResponse::DeviceLocked(LoginDeviceLocked {
+            sms_phone,
+            verify_url,
+            ..
+        }) => {
+            sender.input(LoginFailed(
+                "Device Locked. See more in the pop-up window.".to_string(),
+            ));
+
+            sender.input(LoginPageMsg::DeviceLock(
+                verify_url.unwrap_or_else(|| "<unknown>".into()),
+                sms_phone,
+            ));
+        }
+        LoginResponse::TooManySMSRequest => {
+            sender.input(LoginFailed("Too Many SMS Request".to_string()));
+        }
+        LoginResponse::DeviceLockLogin(_) => {
+            if let Err(err) = client.device_lock_login().await {
+                sender.input(LoginFailed(err.to_string()));
+            } else {
+                finish_login(account, password, client).await;
+            }
+        }
+        LoginResponse::UnknownStatus(LoginUnknownStatus { message, .. }) => {
+            sender.input(LoginFailed(message));
+        }
+    }
+}

--- a/src/app/login/service/login_server.rs
+++ b/src/app/login/service/login_server.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ricq::{client::Token, Client, LoginResponse};
+use ricq::{client::Token, LoginResponse};
 use tokio::{sync::mpsc, task::JoinHandle};
 
 use crate::app::login::LoginPageMsg;
@@ -9,7 +9,8 @@ use super::{handle_respond::handle_login_response, init_client};
 
 pub enum Login {
     Pwd(i64, String),
-    Token(Token),
+    Token(Box<Token>),
+    #[allow(dead_code)]
     QrCode,
 }
 
@@ -18,6 +19,7 @@ pub enum Input {
     Login(Login),
     // login proc
     LoginRespond(Box<LoginResponse>),
+    #[allow(dead_code)]
     Stop,
 }
 
@@ -37,7 +39,6 @@ impl Sender {
                     "Login in Handle receive end closed".into(),
                 ))
             }
-            ()
         });
     }
 }
@@ -74,10 +75,10 @@ impl LoginHandle {
                 match input {
                     Input::Login(login) => match login {
                         Login::Pwd(account, pwd) => {
-                            super::pwd_login::login(account, pwd, &self.sender,&self.client).await;
+                            super::pwd_login::login(account, pwd, &self.sender, &self.client).await;
                         }
                         Login::Token(token) => {
-                            super::token::token_login(token, &self.sender,&self.client).await;
+                            super::token::token_login(*token, &self.sender, &self.client).await;
                         }
                         Login::QrCode => {
                             todo!()

--- a/src/app/login/service/login_server.rs
+++ b/src/app/login/service/login_server.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+
+use ricq::{client::Token, Client, LoginResponse};
+use tokio::{sync::mpsc, task::JoinHandle};
+
+use crate::app::login::LoginPageMsg;
+
+use super::{handle_respond::handle_login_response, init_client};
+
+pub enum Login {
+    Pwd(i64, String),
+    Token(Token),
+    QrCode,
+}
+
+pub enum Input {
+    // login
+    Login(Login),
+    // login proc
+    LoginRespond(Box<LoginResponse>),
+    Stop,
+}
+
+#[derive(Debug, Clone)]
+pub struct Sender {
+    tx: mpsc::Sender<Input>,
+    sender: relm4::Sender<LoginPageMsg>,
+}
+
+pub struct LoginHandle {
+    client: Arc<ricq::Client>,
+    rx: mpsc::Receiver<Input>,
+    sender: relm4::Sender<LoginPageMsg>,
+    inner_send: Sender,
+}
+
+impl LoginHandle {
+    pub async fn new(sender: relm4::Sender<LoginPageMsg>) -> LoginHandle {
+        let client = init_client().await.expect("Init Client Error");
+        let (tx, rx) = mpsc::channel(8);
+
+        Self {
+            client,
+            rx,
+            sender: sender.clone(),
+            inner_send: Sender { tx, sender },
+        }
+    }
+
+    pub fn get_sender(&self) -> Sender {
+        self.inner_send.clone()
+    }
+}
+
+impl LoginHandle {
+    pub fn start_handle(mut self) -> JoinHandle<Arc<Client>> {
+        let task = async move {
+            while let Some(input) = self.rx.recv().await {
+                match input {
+                    Input::Login(login) => match login {
+                        Login::Pwd(account, pwd) => {
+                            super::pwd_login::login(account, pwd, &self.sender).await;
+                        }
+                        Login::Token(token) => {
+                            super::token::token_login(token, &self.sender).await;
+                        }
+                        Login::QrCode => {
+                            todo!()
+                        }
+                    },
+                    Input::LoginRespond(resp) => {
+                        handle_login_response(&resp, Arc::clone(&self.client), &self.sender).await;
+                    }
+                    Input::Stop => break,
+                }
+            }
+
+            self.client
+        };
+
+        tokio::spawn(task)
+    }
+}

--- a/src/app/login/service/pwd_login.rs
+++ b/src/app/login/service/pwd_login.rs
@@ -1,6 +1,6 @@
 use ricq::Client;
 
-use crate::app::login::{service::init_client, LoginPageMsg};
+use crate::app::login::LoginPageMsg;
 
 pub(crate) async fn login(
     account: i64,

--- a/src/app/login/service/pwd_login.rs
+++ b/src/app/login/service/pwd_login.rs
@@ -1,26 +1,25 @@
-use crate::app::login::{
-    service::{handle_login_response, init_client},
-    LOGIN_SENDER,
-};
+use crate::app::login::{service::init_client, LOGIN_SENDER};
 
 pub(crate) async fn login(account: i64, password: String) {
-    use crate::app::login::LoginPageMsg::LoginFailed;
+    use crate::app::login::LoginPageMsg::{LoginFailed, LoginRespond};
     let sender = LOGIN_SENDER.get().unwrap();
 
-    let client = match init_client().await {
-        Ok(client) => client,
-        Err(err) => {
-            sender.input(LoginFailed(err.to_string()));
-            return;
-        }
+    let operate = || async {
+        let client = init_client().await.map_err(|err| err.to_string())?;
+
+        sender.input(LoginRespond(
+            client
+                .password_login(account, &password)
+                .await
+                .map_err(|err| err.to_string())?
+                .into(),
+            client,
+        ));
+
+        Result::<_, String>::Ok(())
     };
 
-    let res = match client.password_login(account, &password).await {
-        Ok(res) => res,
-        Err(err) => {
-            sender.input(LoginFailed(err.to_string()));
-            return;
-        }
-    };
-    handle_login_response(&res, client).await;
+    if let Err(err) = operate().await {
+        sender.input(LoginFailed(err))
+    }
 }

--- a/src/app/login/service/pwd_login.rs
+++ b/src/app/login/service/pwd_login.rs
@@ -22,5 +22,5 @@ pub(crate) async fn login(account: i64, password: String) {
             return;
         }
     };
-    handle_login_response(res, client).await;
+    handle_login_response(&res, client).await;
 }

--- a/src/app/login/service/pwd_login.rs
+++ b/src/app/login/service/pwd_login.rs
@@ -22,5 +22,5 @@ pub(crate) async fn login(account: i64, password: String) {
             return;
         }
     };
-    handle_login_response(res, account, password, client).await;
+    handle_login_response(res, client).await;
 }

--- a/src/app/login/service/pwd_login.rs
+++ b/src/app/login/service/pwd_login.rs
@@ -1,13 +1,12 @@
-use crate::app::login::{service::init_client, LOGIN_SENDER};
+use crate::app::login::{service::init_client, LoginPageMsg};
 
-pub(crate) async fn login(account: i64, password: String) {
+pub(crate) async fn login(account: i64, password: String, sender: relm4::Sender<LoginPageMsg>) {
     use crate::app::login::LoginPageMsg::{LoginFailed, LoginRespond};
-    let sender = LOGIN_SENDER.get().unwrap();
 
     let operate = || async {
         let client = init_client().await.map_err(|err| err.to_string())?;
 
-        sender.input(LoginRespond(
+        sender.send(LoginRespond(
             client
                 .password_login(account, &password)
                 .await
@@ -20,6 +19,6 @@ pub(crate) async fn login(account: i64, password: String) {
     };
 
     if let Err(err) = operate().await {
-        sender.input(LoginFailed(err))
+        sender.send(LoginFailed(err))
     }
 }

--- a/src/app/login/service/pwd_login.rs
+++ b/src/app/login/service/pwd_login.rs
@@ -1,18 +1,22 @@
+use ricq::Client;
+
 use crate::app::login::{service::init_client, LoginPageMsg};
 
-pub(crate) async fn login(account: i64, password: String, sender: &relm4::Sender<LoginPageMsg>) {
+pub(crate) async fn login(
+    account: i64,
+    password: String,
+    sender: &relm4::Sender<LoginPageMsg>,
+    client: &Client,
+) {
     use crate::app::login::LoginPageMsg::{LoginFailed, LoginRespond};
 
     let operate = || async {
-        let client = init_client().await.map_err(|err| err.to_string())?;
-
         sender.send(LoginRespond(
             client
                 .password_login(account, &password)
                 .await
                 .map_err(|err| err.to_string())?
                 .into(),
-            client,
         ));
 
         Result::<_, String>::Ok(())

--- a/src/app/login/service/pwd_login.rs
+++ b/src/app/login/service/pwd_login.rs
@@ -1,6 +1,6 @@
 use crate::app::login::{service::init_client, LoginPageMsg};
 
-pub(crate) async fn login(account: i64, password: String, sender: relm4::Sender<LoginPageMsg>) {
+pub(crate) async fn login(account: i64, password: String, sender: &relm4::Sender<LoginPageMsg>) {
     use crate::app::login::LoginPageMsg::{LoginFailed, LoginRespond};
 
     let operate = || async {

--- a/src/app/login/service/pwd_login.rs
+++ b/src/app/login/service/pwd_login.rs
@@ -1,0 +1,26 @@
+use crate::app::login::{
+    service::{handle_login_response, init_client},
+    LOGIN_SENDER,
+};
+
+pub(crate) async fn login(account: i64, password: String) {
+    use crate::app::login::LoginPageMsg::LoginFailed;
+    let sender = LOGIN_SENDER.get().unwrap();
+
+    let client = match init_client().await {
+        Ok(client) => client,
+        Err(err) => {
+            sender.input(LoginFailed(err.to_string()));
+            return;
+        }
+    };
+
+    let res = match client.password_login(account, &password).await {
+        Ok(res) => res,
+        Err(err) => {
+            sender.input(LoginFailed(err.to_string()));
+            return;
+        }
+    };
+    handle_login_response(res, account, password, client).await;
+}

--- a/src/app/login/service/token.rs
+++ b/src/app/login/service/token.rs
@@ -21,8 +21,7 @@ impl LocalAccount {
 
     fn base64_to_token(base64: &str) -> Token {
         let vec = base64::decode(base64).expect("Bad Base64 Encode");
-        let token = bincode::deserialize(&vec).expect("Bad Bincode format");
-        token
+        bincode::deserialize(&vec).expect("Bad Bincode format")
     }
 
     pub async fn new(client: &Client) -> Self {

--- a/src/app/login/service/token.rs
+++ b/src/app/login/service/token.rs
@@ -61,17 +61,9 @@ impl LocalAccount {
     }
 }
 
-pub async fn token_login(token: Token, sender: &Sender<LoginPageMsg>) {
-    let client = match init_client().await {
-        Ok(client) => client,
-        Err(err) => {
-            sender.send(LoginFailed(err.to_string()));
-            return;
-        }
-    };
-
+pub async fn token_login(token: Token, sender: &Sender<LoginPageMsg>, client: &Client) {
     match client.token_login(token).await {
-        Ok(resp) => sender.send(LoginRespond(resp.into(), client)),
+        Ok(resp) => sender.send(LoginRespond(resp.into())),
         Err(err) => sender.send(LoginFailed(err.to_string())),
     }
 }

--- a/src/app/login/service/token.rs
+++ b/src/app/login/service/token.rs
@@ -7,8 +7,6 @@ use ricq::{client::Token, Client};
 
 use crate::app::login::LoginPageMsg;
 
-use super::init_client;
-
 pub struct LocalAccount {
     pub account: i64,
     pub token: Token,

--- a/src/app/login/service/token.rs
+++ b/src/app/login/service/token.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app::login::LoginPageMsg::LoginFailed,
+    app::login::LoginPageMsg::{LoginFailed, LoginRespond},
     db::sql::{load_sql_config, save_sql_config},
 };
 use relm4::Sender;
@@ -7,7 +7,7 @@ use ricq::{client::Token, Client};
 
 use crate::app::login::LoginPageMsg;
 
-use super::{handle_respond::handle_login_response, init_client};
+use super::init_client;
 
 pub struct LocalAccount {
     pub account: i64,
@@ -71,7 +71,7 @@ pub async fn token_login(token: Token, sender: Sender<LoginPageMsg>) {
     };
 
     match client.token_login(token).await {
-        Ok(resp) => handle_login_response(&resp, client.clone()).await,
+        Ok(resp) => sender.send(LoginRespond(resp.into(), client)),
         Err(err) => sender.send(LoginFailed(err.to_string())),
     }
 }

--- a/src/app/login/service/token.rs
+++ b/src/app/login/service/token.rs
@@ -61,7 +61,7 @@ impl LocalAccount {
     }
 }
 
-pub async fn token_login(token: Token, sender: Sender<LoginPageMsg>) {
+pub async fn token_login(token: Token, sender: &Sender<LoginPageMsg>) {
     let client = match init_client().await {
         Ok(client) => client,
         Err(err) => {

--- a/src/app/login/service/token.rs
+++ b/src/app/login/service/token.rs
@@ -1,6 +1,3 @@
-// TODO: temp tag waiting for other impl
-#![allow(dead_code)]
-
 use crate::app::login::LoginPageMsg::LoginFailed;
 use relm4::Sender;
 use ricq::{client::Token, Client};
@@ -64,9 +61,7 @@ impl LocalAccount {
         let next = rows.next().unwrap();
 
         let account: i64 = next
-            .and_then(|row| {
-                row.get::<_,String>(0).ok()
-            })
+            .and_then(|row| row.get::<_, String>(0).ok())
             .and_then(|v| v.parse().ok())?;
 
         let mut stmt = conn

--- a/src/app/login/service/token.rs
+++ b/src/app/login/service/token.rs
@@ -71,7 +71,7 @@ pub async fn token_login(token: Token, sender: Sender<LoginPageMsg>) {
     };
 
     match client.token_login(token).await {
-        Ok(resp) => handle_login_response(resp, client.clone()).await,
+        Ok(resp) => handle_login_response(&resp, client.clone()).await,
         Err(err) => sender.send(LoginFailed(err.to_string())),
     }
 }

--- a/src/app/login/service/token.rs
+++ b/src/app/login/service/token.rs
@@ -1,0 +1,74 @@
+// TODO: temp tag waiting for other impl
+#![allow(dead_code)]
+
+use crate::app::login::LoginPageMsg::LoginFailed;
+use relm4::Sender;
+use ricq::{client::Token, Client};
+use rusqlite::params;
+
+use crate::{app::login::LoginPageMsg, db::sql::get_db};
+
+pub struct LocalAccount {
+    pub account: i64,
+    pub token: Token,
+}
+
+impl LocalAccount {
+    fn token_to_base64(token: &Token) -> String {
+        let vec = bincode::serialize(&token).expect("serde token error");
+        base64::encode(vec)
+    }
+
+    fn base64_to_token(base64: &str) -> Token {
+        let vec = base64::decode(base64).expect("Bad Base64 Encode");
+        let token = bincode::deserialize(&vec).expect("Bad Bincode format");
+        token
+    }
+
+    pub async fn new(client: &Client) -> Self {
+        let uin = client.uin().await;
+        let token = client.gen_token().await;
+
+        Self {
+            account: uin,
+            token,
+        }
+    }
+
+    pub fn save_account(&self, sender: &Sender<LoginPageMsg>) {
+        let account = self.account.to_string();
+        let token = Self::token_to_base64(&self.token);
+        let db = get_db();
+        if let Err(err) = db.execute(
+            "REPLACE INTO configs (key, value) VALUES (?1, ?2)",
+            params!["account", account],
+        ) {
+            sender.send(LoginFailed(err.to_string()));
+        }
+        if let Err(err) = db.execute(
+            "REPLACE INTO configs (key, value) VALUES (?1, ?2)",
+            params!["token", &token],
+        ) {
+            sender.send(LoginFailed(err.to_string()));
+        }
+    }
+
+    pub fn get_account() -> Option<Self> {
+        let conn = get_db();
+        let mut stmt = conn
+            .prepare("SELECT value FROM configs where key='account'")
+            .unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        let account: i64 = rows.next().unwrap().and_then(|row| row.get(0).ok())?;
+
+        let mut stmt = conn
+            .prepare("SELECT value FROM configs where key='token'")
+            .unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        let token: String = rows.next().unwrap().and_then(|row| row.get(0).ok())?;
+
+        let token = Self::base64_to_token(&token);
+
+        Some(Self { account, token })
+    }
+}

--- a/src/db/sql.rs
+++ b/src/db/sql.rs
@@ -235,8 +235,8 @@ pub fn check_db_version() {
 
 pub fn load_sql_config(key: &impl AsRef<str>) -> Result<Option<String>, rusqlite::Error> {
     let conn = get_db();
-    let mut stmt = conn.prepare("SELECT value FROM configs where key='?'")?;
-    let mut query = stmt.query(&[key.as_ref()])?;
+    let mut stmt = conn.prepare("SELECT value FROM configs where key= ? ")?;
+    let mut query = stmt.query(params![key.as_ref()])?;
     query.next()?.map(|row| row.get::<_, String>(0)).transpose()
 }
 
@@ -251,4 +251,19 @@ pub fn save_sql_config(
         params![key.as_ref(), value.as_ref()],
     )
     .map(|_| ())
+}
+
+
+#[cfg(test)]
+mod test{
+    
+    use crate::db::sql::load_sql_config;
+
+#[test]
+    fn test_account_load() {
+        let acc = load_sql_config(&"account");   
+
+        println!("{acc:?}")
+    }
+
 }

--- a/src/db/sql.rs
+++ b/src/db/sql.rs
@@ -233,7 +233,9 @@ pub fn check_db_version() {
     }
 }
 
-pub fn load_sql_config(key: &impl AsRef<str>) -> Result<Option<String>, rusqlite::Error> {
+pub fn load_sql_config(
+    key: &(impl AsRef<str> + ?Sized),
+) -> Result<Option<String>, rusqlite::Error> {
     let conn = get_db();
     let mut stmt = conn.prepare("SELECT value FROM configs where key= ? ")?;
     let mut query = stmt.query(params![key.as_ref()])?;
@@ -241,8 +243,8 @@ pub fn load_sql_config(key: &impl AsRef<str>) -> Result<Option<String>, rusqlite
 }
 
 pub fn save_sql_config(
-    key: &impl AsRef<str>,
-    value: &impl AsRef<str>,
+    key: &(impl AsRef<str> + ?Sized),
+    value: impl AsRef<str>,
 ) -> Result<(), rusqlite::Error> {
     let db = get_db();
 
@@ -260,7 +262,7 @@ mod test {
 
     #[test]
     fn test_account_load() {
-        let acc = load_sql_config(&"account");
+        let acc = load_sql_config("account");
 
         println!("{acc:?}")
     }

--- a/src/db/sql.rs
+++ b/src/db/sql.rs
@@ -232,3 +232,26 @@ pub fn check_db_version() {
         }
     }
 }
+
+pub fn load_sql_config(key: &impl AsRef<str>) -> Result<Option<String>, rusqlite::Error> {
+    let conn = get_db();
+    let mut stmt = conn.prepare("SELECT value FROM configs where key='?'")?;
+    let mut query = stmt.query(&[key.as_ref()])?;
+    Ok(query
+        .next()?
+        .map(|row| row.get::<_, String>(0))
+        .transpose()?)
+}
+
+pub fn save_sql_config(
+    key: &impl AsRef<str>,
+    value: &impl AsRef<str>,
+) -> Result<(), rusqlite::Error> {
+    let db = get_db();
+
+    db.execute(
+        "REPLACE INTO configs (key, value) VALUES (?1, ?2)",
+        params![key.as_ref(), value.as_ref()],
+    )
+    .map(|_| ())
+}

--- a/src/db/sql.rs
+++ b/src/db/sql.rs
@@ -253,17 +253,15 @@ pub fn save_sql_config(
     .map(|_| ())
 }
 
-
 #[cfg(test)]
-mod test{
-    
+mod test {
+
     use crate::db::sql::load_sql_config;
 
-#[test]
+    #[test]
     fn test_account_load() {
-        let acc = load_sql_config(&"account");   
+        let acc = load_sql_config(&"account");
 
         println!("{acc:?}")
     }
-
 }

--- a/src/db/sql.rs
+++ b/src/db/sql.rs
@@ -237,10 +237,7 @@ pub fn load_sql_config(key: &impl AsRef<str>) -> Result<Option<String>, rusqlite
     let conn = get_db();
     let mut stmt = conn.prepare("SELECT value FROM configs where key='?'")?;
     let mut query = stmt.query(&[key.as_ref()])?;
-    Ok(query
-        .next()?
-        .map(|row| row.get::<_, String>(0))
-        .transpose()?)
+    query.next()?.map(|row| row.get::<_, String>(0)).transpose()
 }
 
 pub fn save_sql_config(


### PR DESCRIPTION
- [x] 登录逻辑重构
  - [x] 密码登录模块独立
  - [x] 解除device的随机种子与账号关联
    - [x] 使用配置文件提供登录设备协议和device随机种子 
  - [x] 记住密码采用保存token而不是密码来实现
  - [x] 支持 `记住密码`、`自动登录` 功能
    - [x] `记住密码`
    - [x] ~`自动登录`~  **由于当前不支持登出，暂时不可用** 
  - [x] 为QR code 登录预留支持
    - [x] `handle_login_respond` 更改为接收 `&LoginRespond` 
    - [x] 独立处理登录处理逻辑
  