### PR TITLE
Added a method to install ArchLinux using the AUR build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ sudo dnf install gtk4-devel libadwaita-devel
 
 #### Arch
 
+Via AUR
+```
+paru -S gtk-qq-git
+```
+
+Or do it manually
 ```bash
 sudo pacman -S pkgconf gtk4 libadwaita
 ```

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ sudo dnf install gtk4-devel libadwaita-devel
 
 #### Arch
 
-Via AUR
+Complete build Via AUR PKGBUILD
 ```
 paru -S gtk-qq-git
 ```
 
-Or do it manually
+Or do it manually，Then follow the instructions below
 ```bash
 sudo pacman -S pkgconf gtk4 libadwaita
 ```


### PR DESCRIPTION
I uploaded a PKGBUILD on AUR to make it easier to build and install this software, as the binaries in the release don't seem to work with ArchLinux and will prompt "error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory"