### PR TITLE
♻️ (device-lock) show error message when no verify url

### DIFF
--- a/libs/widgets/src/pwd_login/widgets.rs
+++ b/libs/widgets/src/pwd_login/widgets.rs
@@ -83,7 +83,7 @@ impl PwdLoginWidget {
                 }
             }
         }
-        
+
         relm4::view! {
             #[name = "avatar"]
             Avatar {

--- a/src/app/login/service/handle_respond.rs
+++ b/src/app/login/service/handle_respond.rs
@@ -62,11 +62,13 @@ pub(in crate::app) async fn handle_login_response(
             sender.send(LoginFailed(
                 "Device Locked. See more in the pop-up window.".to_string(),
             ));
-
-            sender.send(LoginPageMsg::DeviceLock(
-                verify_url.clone().unwrap_or_else(|| "<unknown>".into()),
-                sms_phone.clone(),
-            ));
+            let verify_url = if let Some(url) = verify_url {
+                url.to_owned()
+            } else {
+                sender.send(LoginFailed("Cannot Fetch Device Lock".to_string()));
+                return;
+            };
+            sender.send(LoginPageMsg::DeviceLock(verify_url, sms_phone.clone()));
         }
         LoginResponse::TooManySMSRequest => {
             sender.send(LoginFailed("Too Many SMS Request".to_string()));


### PR DESCRIPTION
当没有取得设备锁Verify Url 时不弹出窗口并显示错误信息
这是 针对 #35 问题的表面的修复